### PR TITLE
Issue#194 Make maven log less verbose on CI build

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -19,8 +19,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          API_TESTS_VERBOSE_LOGGING: false
         run: >-
-          mvn -V -e -B
+          mvn -V -e -B -ntp
           clean deploy sonar:sonar
           -Papi-tests-infrastructure
           -Papi-tests
@@ -32,6 +33,7 @@ jobs:
           -Dhome.application.admin.password=${{secrets.HOME_APPLICATION_ADMIN_PASSWORD}}
           -Ddockerhub.username=${{secrets.DOCKER_USERNAME}}
           -Ddockerhub.password=${{secrets.DOCKER_PASSWORD}}
+          -Dapi.tests.verbose.logging=${{env.API_TESTS_VERBOSE_LOGGING}}
 
   deploy:
     needs: package

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: >-
-          mvn -V -e -B
+          mvn -V -e -B -ntp
           clean install sonar:sonar
           -Papi-tests-infrastructure
           -Papi-tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          DOCKER_INFO: false
+          API_TESTS_VERBOSE_LOGGING: false
         run: >-
           mvn -V -e -B -ntp
           clean install sonar:sonar
@@ -30,4 +30,4 @@ jobs:
           -Dpostgres.password=${{secrets.POSTGRES_PASSWORD}}
           -Dhome.application.admin.username=${{secrets.HOME_APPLICATION_ADMIN_USERNAME}}
           -Dhome.application.admin.password=${{secrets.HOME_APPLICATION_ADMIN_PASSWORD}}
-          -Ddocker.infrastructure=$DOCKER_INFO
+          -Dapi.tests.verbose.logging=${{env.API_TESTS_VERBOSE_LOGGING}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          DOCKER_INFO: false
         run: >-
           mvn -V -e -B -ntp
           clean install sonar:sonar
@@ -29,3 +30,4 @@ jobs:
           -Dpostgres.password=${{secrets.POSTGRES_PASSWORD}}
           -Dhome.application.admin.username=${{secrets.HOME_APPLICATION_ADMIN_USERNAME}}
           -Dhome.application.admin.password=${{secrets.HOME_APPLICATION_ADMIN_PASSWORD}}
+          -Ddocker.infrastructure=$DOCKER_INFO

--- a/home-api-tests/pom.xml
+++ b/home-api-tests/pom.xml
@@ -299,6 +299,7 @@
                                 <liquibase.external.port>${liquibase.external.port}</liquibase.external.port>
                                 <home.application.admin.username>${home.application.admin.username}</home.application.admin.username>
                                 <home.application.admin.password>${home.application.admin.password}</home.application.admin.password>
+                                <verbose.tests.logging>${docker.infrastructure}</verbose.tests.logging>
                             </systemPropertyVariables>
                         </configuration>
                         <executions>

--- a/home-api-tests/pom.xml
+++ b/home-api-tests/pom.xml
@@ -21,7 +21,7 @@
         <docker.image.data.migration>home-data-migration:${revision}</docker.image.data.migration>
         <docker.image.application>home-application:${revision}</docker.image.application>
         <docker.image.postgres>postgres</docker.image.postgres>
-        <docker.infrastructure>${docker.infrastructure}</docker.infrastructure>
+        <api.tests.verbose.logging>true</api.tests.verbose.logging>
         <postgres.internal.port>5432</postgres.internal.port>
         <postgres.db>postgres</postgres.db>
         <postgres.url>jdbc:postgresql://${docker.image.postgres}:${postgres.internal.port}/${postgres.db}</postgres.url>
@@ -33,12 +33,6 @@
         <jacoco.agent.internal.port>6300</jacoco.agent.internal.port>
     </properties>
     <profiles>
-        <profile>
-            <id>remove.tests.information</id>
-            <properties>
-                <test.access.information>false</test.access.information>
-            </properties>
-        </profile>
         <profile>
             <id>push.images</id>
             <properties>
@@ -185,7 +179,7 @@
                                             <time>25000</time>
                                         </wait>
                                         <log>
-                                            <enabled>${docker.infrastructure}</enabled>
+                                            <enabled>${api.tests.verbose.logging}</enabled>
                                             <date>default</date>
                                         </log>
                                     </run>
@@ -213,7 +207,7 @@
                                             <time>15000</time>
                                         </wait>
                                         <log>
-                                            <enabled>${docker.infrastructure}</enabled>
+                                            <enabled>${api.tests.verbose.logging}</enabled>
                                             <date>default</date>
                                         </log>
                                     </run>
@@ -250,7 +244,7 @@
                                             <time>300000</time>
                                         </wait>
                                         <log>
-                                            <enabled>${docker.infrastructure}</enabled>
+                                            <enabled>${api.tests.verbose.logging}</enabled>
                                             <date>default</date>
                                         </log>
                                     </run>
@@ -299,7 +293,7 @@
                                 <liquibase.external.port>${liquibase.external.port}</liquibase.external.port>
                                 <home.application.admin.username>${home.application.admin.username}</home.application.admin.username>
                                 <home.application.admin.password>${home.application.admin.password}</home.application.admin.password>
-                                <verbose.tests.logging>${docker.infrastructure}</verbose.tests.logging>
+                                <verbose.tests.logging>${api.tests.verbose.logging}</verbose.tests.logging>
                             </systemPropertyVariables>
                         </configuration>
                         <executions>

--- a/home-api-tests/pom.xml
+++ b/home-api-tests/pom.xml
@@ -21,6 +21,7 @@
         <docker.image.data.migration>home-data-migration:${revision}</docker.image.data.migration>
         <docker.image.application>home-application:${revision}</docker.image.application>
         <docker.image.postgres>postgres</docker.image.postgres>
+        <docker.infrastructure>${docker.infrastructure}</docker.infrastructure>
         <postgres.internal.port>5432</postgres.internal.port>
         <postgres.db>postgres</postgres.db>
         <postgres.url>jdbc:postgresql://${docker.image.postgres}:${postgres.internal.port}/${postgres.db}</postgres.url>
@@ -32,6 +33,12 @@
         <jacoco.agent.internal.port>6300</jacoco.agent.internal.port>
     </properties>
     <profiles>
+        <profile>
+            <id>remove.tests.information</id>
+            <properties>
+                <test.access.information>false</test.access.information>
+            </properties>
+        </profile>
         <profile>
             <id>push.images</id>
             <properties>
@@ -178,7 +185,7 @@
                                             <time>25000</time>
                                         </wait>
                                         <log>
-                                            <enabled>true</enabled>
+                                            <enabled>${docker.infrastructure}</enabled>
                                             <date>default</date>
                                         </log>
                                     </run>
@@ -206,7 +213,7 @@
                                             <time>15000</time>
                                         </wait>
                                         <log>
-                                            <enabled>true</enabled>
+                                            <enabled>${docker.infrastructure}</enabled>
                                             <date>default</date>
                                         </log>
                                     </run>
@@ -243,7 +250,7 @@
                                             <time>300000</time>
                                         </wait>
                                         <log>
-                                            <enabled>true</enabled>
+                                            <enabled>${docker.infrastructure}</enabled>
                                             <date>default</date>
                                         </log>
                                     </run>

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
@@ -18,16 +18,14 @@ public final class ApiClientUtil {
         String verboseLogging = System.getProperty("verbose.tests.logging");
         ApiClient client = new ApiClient();
         Logger logger = Logger.getLogger(ApiClient.class.getName());
-        Level level = Level.INFO;
         if (verboseLogging.equals("false")) {
-            level = Level.OFF;
+            client.getHttpClient()
+                .register(new LoggingFeature(logger, Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 8192));
+            client.setUsername(applicationAdminUsername);
+            client.setPassword(applicationAdminPassword);
+            client.setServers(List.of(new ServerConfiguration("http://localhost:" + applicationExternalPort + "/api/0",
+                "No description provided", new HashMap())));
         }
-        client.getHttpClient()
-            .register(new LoggingFeature(logger, level, LoggingFeature.Verbosity.PAYLOAD_ANY, 8192));
-        client.setUsername(applicationAdminUsername);
-        client.setPassword(applicationAdminPassword);
-        client.setServers(List.of(new ServerConfiguration("http://localhost:" + applicationExternalPort + "/api/0",
-            "No description provided", new HashMap())));
         return client;
     }
 }

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
@@ -15,10 +15,15 @@ public final class ApiClientUtil {
         String applicationExternalPort = System.getProperty("home.application.external.port");
         String applicationAdminUsername = System.getProperty("home.application.admin.username");
         String applicationAdminPassword = System.getProperty("home.application.admin.password");
+        String verboseLogging = System.getProperty("verbose.tests.logging");
         ApiClient client = new ApiClient();
         Logger logger = Logger.getLogger(ApiClient.class.getName());
+        Level level = Level.INFO;
+        if (verboseLogging.equals("false")) {
+            level = Level.WARNING;
+        }
         client.getHttpClient()
-            .register(new LoggingFeature(logger, Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 8192));
+            .register(new LoggingFeature(logger, level, LoggingFeature.Verbosity.PAYLOAD_ANY, 8192));
         client.setUsername(applicationAdminUsername);
         client.setPassword(applicationAdminPassword);
         client.setServers(List.of(new ServerConfiguration("http://localhost:" + applicationExternalPort + "/api/0",

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
@@ -15,13 +15,15 @@ public final class ApiClientUtil {
         String applicationExternalPort = System.getProperty("home.application.external.port");
         String applicationAdminUsername = System.getProperty("home.application.admin.username");
         String applicationAdminPassword = System.getProperty("home.application.admin.password");
-        String verboseLogging = System.getProperty("verbose.tests.logging");
+        String verboseLogging = System.getProperty("verbose.tests.logging", "true");
         ApiClient client = new ApiClient();
         Logger logger = Logger.getLogger(ApiClient.class.getName());
-        if (verboseLogging.equals("true")) {
-            client.getHttpClient()
-                .register(new LoggingFeature(logger, Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 8192));
+        Level levelOfLogging = Level.WARNING;
+        if (Boolean.parseBoolean(verboseLogging)) {
+            levelOfLogging = Level.INFO;
         }
+        client.getHttpClient()
+            .register(new LoggingFeature(logger, levelOfLogging, LoggingFeature.Verbosity.PAYLOAD_ANY, 8192));
         client.setUsername(applicationAdminUsername);
         client.setPassword(applicationAdminPassword);
         client.setServers(List.of(new ServerConfiguration("http://localhost:" + applicationExternalPort + "/api/0",

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
@@ -10,25 +10,33 @@ import com.softserveinc.ita.homeproject.ServerConfiguration;
 import org.glassfish.jersey.logging.LoggingFeature;
 
 public final class ApiClientUtil {
+    private static final String APPLICATION_EXTERNAL_PORT = System.getProperty("home.application.external.port");
+    private static final String APPLICATION_ADMIN_USER_NAME = System.getProperty("home.application.admin.username");
+    private static final String APPLICATION_ADMIN_PASSWORD = System.getProperty("home.application.admin.password");
+    private static final String VERBOSE_LOGGING = System.getProperty("verbose.tests.logging", "true");
+    private static final ApiClient CLIENT = new ApiClient();
 
     public static ApiClient getClient() {
-        String applicationExternalPort = System.getProperty("home.application.external.port");
-        String applicationAdminUsername = System.getProperty("home.application.admin.username");
-        String applicationAdminPassword = System.getProperty("home.application.admin.password");
-        String verboseLogging = System.getProperty("verbose.tests.logging", "true");
-        ApiClient client = new ApiClient();
-        Logger logger = Logger.getLogger(ApiClient.class.getName());
-        Level levelOfLogging = Level.WARNING;
-        if (Boolean.parseBoolean(verboseLogging)) {
-            levelOfLogging = Level.INFO;
+        setLoggingFeature();
+        CLIENT.setUsername(APPLICATION_ADMIN_USER_NAME);
+        CLIENT.setPassword(APPLICATION_ADMIN_PASSWORD);
+        CLIENT.setServers(List.of(new ServerConfiguration("http://localhost:" +
+            APPLICATION_EXTERNAL_PORT + "/api/0", "No description provided", new HashMap())));
+        return CLIENT;
+    }
+
+    public static ApiClient getUnauthorizedClient() {
+        setLoggingFeature();
+        CLIENT.setServers(List.of(new ServerConfiguration("http://localhost:" +
+            APPLICATION_EXTERNAL_PORT + "/api/0", "No description provided", new HashMap())));
+        return CLIENT;
+    }
+
+    private static void setLoggingFeature() {
+        if (Boolean.parseBoolean(VERBOSE_LOGGING)) {
+            Logger logger = Logger.getLogger(ApiClient.class.getName());
+            CLIENT.getHttpClient()
+               .register(new LoggingFeature(logger, Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 8192));
         }
-        client.getHttpClient()
-            .register(new LoggingFeature(logger, levelOfLogging, LoggingFeature.Verbosity.PAYLOAD_ANY, 8192));
-        client.setUsername(applicationAdminUsername);
-        client.setPassword(applicationAdminPassword);
-        client.setServers(List.of(new ServerConfiguration("http://localhost:" + applicationExternalPort + "/api/0",
-            "No description provided", new HashMap())));
-        return client;
     }
 }
-

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
@@ -18,14 +18,14 @@ public final class ApiClientUtil {
         String verboseLogging = System.getProperty("verbose.tests.logging");
         ApiClient client = new ApiClient();
         Logger logger = Logger.getLogger(ApiClient.class.getName());
-        if (verboseLogging.equals("false")) {
+        if (verboseLogging.equals("true")) {
             client.getHttpClient()
                 .register(new LoggingFeature(logger, Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 8192));
-            client.setUsername(applicationAdminUsername);
-            client.setPassword(applicationAdminPassword);
-            client.setServers(List.of(new ServerConfiguration("http://localhost:" + applicationExternalPort + "/api/0",
-                "No description provided", new HashMap())));
         }
+        client.setUsername(applicationAdminUsername);
+        client.setPassword(applicationAdminPassword);
+        client.setServers(List.of(new ServerConfiguration("http://localhost:" + applicationExternalPort + "/api/0",
+            "No description provided", new HashMap())));
         return client;
     }
 }

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
@@ -14,29 +14,33 @@ public final class ApiClientUtil {
     private static final String APPLICATION_ADMIN_USER_NAME = System.getProperty("home.application.admin.username");
     private static final String APPLICATION_ADMIN_PASSWORD = System.getProperty("home.application.admin.password");
     private static final String VERBOSE_LOGGING = System.getProperty("verbose.tests.logging", "true");
-    private static final ApiClient CLIENT = new ApiClient();
 
     public static ApiClient getClient() {
-        setLoggingFeature();
-        CLIENT.setUsername(APPLICATION_ADMIN_USER_NAME);
-        CLIENT.setPassword(APPLICATION_ADMIN_PASSWORD);
-        CLIENT.setServers(List.of(new ServerConfiguration("http://localhost:" +
-            APPLICATION_EXTERNAL_PORT + "/api/0", "No description provided", new HashMap())));
-        return CLIENT;
+        ApiClient client = new ApiClient();
+        setLoggingFeature(client);
+        client.setUsername(APPLICATION_ADMIN_USER_NAME);
+        client.setPassword(APPLICATION_ADMIN_PASSWORD);
+        setServers(client);
+        return client;
     }
 
     public static ApiClient getUnauthorizedClient() {
-        setLoggingFeature();
-        CLIENT.setServers(List.of(new ServerConfiguration("http://localhost:" +
-            APPLICATION_EXTERNAL_PORT + "/api/0", "No description provided", new HashMap())));
-        return CLIENT;
+        ApiClient client = new ApiClient();
+        setLoggingFeature(client);
+        setServers(client);
+        return client;
     }
 
-    private static void setLoggingFeature() {
+    private static void setLoggingFeature(ApiClient client) {
         if (Boolean.parseBoolean(VERBOSE_LOGGING)) {
             Logger logger = Logger.getLogger(ApiClient.class.getName());
-            CLIENT.getHttpClient()
-               .register(new LoggingFeature(logger, Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 8192));
+            client.getHttpClient()
+                .register(new LoggingFeature(logger, Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 8192));
         }
+    }
+
+    private static void setServers(ApiClient client) {
+        client.setServers(List.of(new ServerConfiguration("http://localhost:" +
+            APPLICATION_EXTERNAL_PORT + "/api/0", "No description provided", new HashMap())));
     }
 }

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
@@ -20,7 +20,7 @@ public final class ApiClientUtil {
         Logger logger = Logger.getLogger(ApiClient.class.getName());
         Level level = Level.INFO;
         if (verboseLogging.equals("false")) {
-            level = Level.WARNING;
+            level = Level.OFF;
         }
         client.getHttpClient()
             .register(new LoggingFeature(logger, level, LoggingFeature.Verbosity.PAYLOAD_ANY, 8192));

--- a/home-clients/pom.xml
+++ b/home-clients/pom.xml
@@ -112,6 +112,7 @@
                     <arguments>
                         <argument>clean</argument>
                         <argument>install</argument>
+                        <argument>-ntp</argument>
                     </arguments>
                     <environmentVariables>
                         <LANG>en_US</LANG>

--- a/home-docs/home-api-tests.md
+++ b/home-docs/home-api-tests.md
@@ -7,6 +7,7 @@ There are several options on how to run home-api-tests.
 Terminal command should look like this:
   
   `mvn clean install
+  -Pjacoco
   -Papi-tests-infrastructure
   -Papi-tests
   -Dpostgres.user={your main postgres superuser}

--- a/home-server-generator/pom.xml
+++ b/home-server-generator/pom.xml
@@ -117,6 +117,7 @@
                     <arguments>
                         <argument>clean</argument>
                         <argument>install</argument>
+                        <argument>-ntp</argument>
                     </arguments>
                     <environmentVariables>
                         <LANG>en_US</LANG>


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/194)


## Code reviewers

- [ ] @kh0ma, @VadymSokorenko, @denis-litvinov, @DzigMS

### Second Level Review

- [ ] @github_username

## Summary of issue

Maven logs on CI have a lot of usless information.

## Summary of change

Add manev key -ntp into CI.yml

## Testing approach

Manual

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions