### PR TITLE
Issue#202 Reuse query service for getOne operation

### DIFF
--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/ContactApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/ContactApiIT.java
@@ -187,7 +187,7 @@ class ContactApiIT {
             .isThrownBy(() -> contactApi
                 .getContactOnUserWithHttpInfo(expectedUser.getId(), wrongId))
             .matches(exception -> exception.getCode() == NOT_FOUND)
-            .withMessageContaining("Can't find contact with given ID:" + wrongId);
+            .withMessageContaining("Contacts with id: " + wrongId + " is not found");
     }
 
     @Test
@@ -198,7 +198,7 @@ class ContactApiIT {
             .isThrownBy(() -> contactApi
                 .getContactOnUserWithHttpInfo(expectedUser.getId(), null))
             .matches(exception -> exception.getCode() == BAD_REQUEST)
-            .withMessageContaining("Missing the required parameter 'contactId' when calling getContactOnUser");
+            .withMessageContaining("Missing the required parameter 'id' when calling getContactOnUser");
     }
 
     @Test
@@ -414,7 +414,7 @@ class ContactApiIT {
         assertThatExceptionOfType(ApiException.class)
             .isThrownBy(() -> contactApi
                 .deleteContactOnUserWithHttpInfo(expectedUser.getId(), null))
-            .withMessageContaining("Missing the required parameter 'contactId' when calling deleteContactOnUser");
+            .withMessageContaining("Missing the required parameter 'id' when calling deleteContactOnUser");
     }
 
     @Test

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/ContactApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/ContactApiIT.java
@@ -187,7 +187,7 @@ class ContactApiIT {
             .isThrownBy(() -> contactApi
                 .getContactOnUserWithHttpInfo(expectedUser.getId(), wrongId))
             .matches(exception -> exception.getCode() == NOT_FOUND)
-            .withMessageContaining("Contacts with id: " + wrongId + " is not found");
+            .withMessageContaining("Entity with id: " + wrongId + " is not found");
     }
 
     @Test

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/ContactApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/ContactApiIT.java
@@ -187,7 +187,8 @@ class ContactApiIT {
             .isThrownBy(() -> contactApi
                 .getContactOnUserWithHttpInfo(expectedUser.getId(), wrongId))
             .matches(exception -> exception.getCode() == NOT_FOUND)
-            .withMessageContaining("Entity with id: " + wrongId + " is not found");
+            .withMessageContaining(
+                "Entity with 'user_id: " + expectedUser.getId() + " and id: " + wrongId + "' is not found");
     }
 
     @Test

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/QueryContactIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/QueryContactIT.java
@@ -157,7 +157,7 @@ class QueryContactIT {
             .userId(expectedUser.getId())
             .pageNumber(1)
             .pageSize(10)
-            .type("email")
+            .type("EMAIL")
             .build().perform();
 
         queryContactsResponse.forEach(contact -> assertThat(contact.getType()).isEqualTo(ContactType.EMAIL));

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/QueryCooperationIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/QueryCooperationIT.java
@@ -128,7 +128,7 @@ class QueryCooperationIT {
             .pageNumber(1)
             .pageSize(10)
             .sort("id,asc")
-            .usreo(expected.getIban())
+            .iban(expected.getIban())
             .build().perform();
 
         queryResponse.forEach(element -> assertEquals(element.getIban(), expected.getIban()));

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/news/NewsApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/news/NewsApiIT.java
@@ -237,7 +237,7 @@ class NewsApiIT {
         assertThatExceptionOfType(ApiException.class)
             .isThrownBy(() -> newsApi.getNewsWithHttpInfo(wrongId))
             .matches(exception -> exception.getCode() == NOT_FOUND)
-            .withMessageContaining("Entity with id: " + wrongId + " is not found");
+            .withMessageContaining("Entity with 'id: " + wrongId + "' is not found");
     }
 
     @Test

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/news/NewsApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/news/NewsApiIT.java
@@ -237,7 +237,7 @@ class NewsApiIT {
         assertThatExceptionOfType(ApiException.class)
             .isThrownBy(() -> newsApi.getNewsWithHttpInfo(wrongId))
             .matches(exception -> exception.getCode() == NOT_FOUND)
-            .withMessageContaining("News with id: " + wrongId + " is not found");
+            .withMessageContaining("Entity with id: " + wrongId + " is not found");
     }
 
     @Test

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/news/NewsApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/news/NewsApiIT.java
@@ -237,7 +237,7 @@ class NewsApiIT {
         assertThatExceptionOfType(ApiException.class)
             .isThrownBy(() -> newsApi.getNewsWithHttpInfo(wrongId))
             .matches(exception -> exception.getCode() == NOT_FOUND)
-            .withMessageContaining("Can't find news with given ID: " + wrongId);
+            .withMessageContaining("News with id: " + wrongId + " is not found");
     }
 
     @Test

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/UserApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/UserApiIT.java
@@ -218,14 +218,14 @@ class UserApiIT {
         assertThatExceptionOfType(ApiException.class)
             .isThrownBy(() -> userApi.getUserWithHttpInfo(userId))
             .matches(exception -> exception.getCode() == NOT_FOUND)
-            .withMessageContaining("User with id: " + userId + " is not found");
+            .withMessageContaining("Users with id: " + userId + " is not found");
     }
 
     @Test
     void passNullWhenReceivingTest() {
         assertThatExceptionOfType(ApiException.class)
             .isThrownBy(() -> userApi.getUserWithHttpInfo(null))
-            .withMessageContaining("Missing the required parameter 'userId' when calling getUser");
+            .withMessageContaining("Missing the required parameter 'id' when calling getUser");
     }
 
     @Test
@@ -346,7 +346,7 @@ class UserApiIT {
     void passNullWhenDeleteUserTest() {
         assertThatExceptionOfType(ApiException.class)
             .isThrownBy(() -> userApi.deleteUserWithHttpInfo(null))
-            .withMessageContaining("Missing the required parameter 'userId' when calling deleteUser");
+            .withMessageContaining("Missing the required parameter 'id' when calling deleteUser");
     }
 
     private List<CreateContact> createContactList() {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/UserApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/UserApiIT.java
@@ -218,7 +218,7 @@ class UserApiIT {
         assertThatExceptionOfType(ApiException.class)
             .isThrownBy(() -> userApi.getUserWithHttpInfo(userId))
             .matches(exception -> exception.getCode() == NOT_FOUND)
-            .withMessageContaining("Entity with id: " + userId + " is not found");
+            .withMessageContaining("Entity with 'id: " + userId + "' is not found");
     }
 
     @Test

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/UserApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/UserApiIT.java
@@ -218,7 +218,7 @@ class UserApiIT {
         assertThatExceptionOfType(ApiException.class)
             .isThrownBy(() -> userApi.getUserWithHttpInfo(userId))
             .matches(exception -> exception.getCode() == NOT_FOUND)
-            .withMessageContaining("Users with id: " + userId + " is not found");
+            .withMessageContaining("Entity with id: " + userId + " is not found");
     }
 
     @Test

--- a/home-application/pom.xml
+++ b/home-application/pom.xml
@@ -11,6 +11,10 @@
     <packaging>jar</packaging>
     <artifactId>home-application</artifactId>
 
+    <properties>
+        <surefire-version>3.0.0-M5</surefire-version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -33,6 +37,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>com.softserveinc.ita.homeproject</groupId>
             <artifactId>home-data-migration</artifactId>
@@ -123,6 +128,14 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-version}</version>
+                <configuration>
+                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>

--- a/home-application/pom.xml
+++ b/home-application/pom.xml
@@ -150,6 +150,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CommonApi.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CommonApi.java
@@ -29,12 +29,9 @@ public abstract class CommonApi {
     protected HomeMapper mapper;
 
     @Autowired
-    protected EntitySpecificationService entitySpecificationService;
-
-    @Autowired
     protected QueryApiService queryApiService;
 
-    <T extends BaseDto> Response buildQueryResponse(Page<T> page, Class<? extends BaseReadView> clazz) {
+    protected <T extends BaseDto> Response buildQueryResponse(Page<T> page, Class<? extends BaseReadView> clazz) {
         long totalElements = page.getTotalElements();
         int totalPages = page.getTotalPages();
         int numberOfElements = page.getNumberOfElements();

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CommonApi.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CommonApi.java
@@ -7,7 +7,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import com.softserveinc.ita.homeproject.application.mapper.HomeMapper;
-import com.softserveinc.ita.homeproject.application.service.EntitySpecificationService;
 import com.softserveinc.ita.homeproject.application.service.QueryApiService;
 import com.softserveinc.ita.homeproject.homeservice.dto.BaseDto;
 import com.softserveinc.ita.homeproject.model.BaseReadView;

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CooperationApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CooperationApiImpl.java
@@ -19,6 +19,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
 import com.softserveinc.ita.homeproject.api.CooperationApi;
+import com.softserveinc.ita.homeproject.homeservice.dto.ContactDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.CooperationDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.HouseDto;
 import com.softserveinc.ita.homeproject.homeservice.service.CooperationService;
@@ -67,7 +68,7 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
     @PreAuthorize(GET_COOPERATION_PERMISSION)
     @Override
     public Response getCooperation(Long cooperationId) {
-        CooperationDto readCoopDto = cooperationService.getCooperationById(cooperationId);
+        CooperationDto readCoopDto = (CooperationDto) queryApiService.getOne(uriInfo, cooperationService);
         ReadCooperation readCoop = mapper.convert(readCoopDto, ReadCooperation.class);
 
         return Response.status(Response.Status.OK).entity(readCoop).build();
@@ -77,7 +78,7 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
     @PreAuthorize(GET_HOUSE_PERMISSION)
     @Override
     public Response getHouse(Long cooperationId, Long houseId) {
-        HouseDto toGet = houseService.getHouseById(cooperationId, houseId);
+        HouseDto toGet = (HouseDto) queryApiService.getOne(uriInfo, houseService);
         ReadHouse readHouse = mapper.convert(toGet, ReadHouse.class);
 
         return Response.status(Response.Status.OK).entity(readHouse).build();

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CooperationApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CooperationApiImpl.java
@@ -19,7 +19,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
 import com.softserveinc.ita.homeproject.api.CooperationApi;
-import com.softserveinc.ita.homeproject.homeservice.dto.ContactDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.CooperationDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.HouseDto;
 import com.softserveinc.ita.homeproject.homeservice.service.CooperationService;

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/NewsApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/NewsApiImpl.java
@@ -11,7 +11,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
 import com.softserveinc.ita.homeproject.api.NewsApi;
-import com.softserveinc.ita.homeproject.homeservice.dto.ContactDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.NewsDto;
 import com.softserveinc.ita.homeproject.homeservice.service.NewsService;
 import com.softserveinc.ita.homeproject.model.CreateNews;

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/NewsApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/NewsApiImpl.java
@@ -11,6 +11,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
 import com.softserveinc.ita.homeproject.api.NewsApi;
+import com.softserveinc.ita.homeproject.homeservice.dto.ContactDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.NewsDto;
 import com.softserveinc.ita.homeproject.homeservice.service.NewsService;
 import com.softserveinc.ita.homeproject.model.CreateNews;
@@ -100,7 +101,7 @@ public class NewsApiImpl extends CommonApi implements NewsApi {
     @PreAuthorize(GET_NEWS_PERMISSION)
     @Override
     public Response getNews(Long id) {
-        NewsDto readNewsDto = newsService.getById(id);
+        NewsDto readNewsDto = (NewsDto) queryApiService.getOne(uriInfo, newsService);
         ReadNews newsApiResponse = mapper.convert(readNewsDto, ReadNews.class);
 
         return Response.ok().entity(newsApiResponse).build();

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
@@ -80,7 +80,7 @@ public class UserApiImpl extends CommonApi implements UsersApi {
     @PreAuthorize(GET_USER_BY_ID_PERMISSION)
     @Override
     public Response getUser(Long id) {
-        UserDto readUserDto = userService.getUserById(id);
+        UserDto readUserDto = (UserDto) queryApiService.getOne(uriInfo, userService);
         ReadUser readUser = mapper.convert(readUserDto, ReadUser.class);
 
         return Response.status(Response.Status.OK).entity(readUser).build();
@@ -138,7 +138,7 @@ public class UserApiImpl extends CommonApi implements UsersApi {
 
     @Override
     public Response getContactOnUser(Long userId, Long contactId) {
-        ContactDto readContactDto = contactService.getContactById(contactId);
+        ContactDto readContactDto = (ContactDto) queryApiService.getOne(uriInfo, contactService);
         ReadContact readContact = mapper.convert(readContactDto, ReadContact.class);
 
         return Response.status(Response.Status.OK).entity(readContact).build();

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
@@ -108,6 +108,12 @@ public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
         }
     }
 
+    private static String getMessage(NotFoundHomeException e, UriInfo uriInfo) {
+        String entityName = e.getMessage().split(" ")[1];
+        return entityName + " with id: " + getParameterValue("id", uriInfo)
+            .orElse("'not defined'") + " is not found";
+    }
+
     /**
      * @param uriInfo - object that implements UriInfo interface
      *                  that provides access to application and request URI information
@@ -121,8 +127,7 @@ public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
         try {
             page = getPageFromQuery(uriInfo, service);
         } catch (NotFoundHomeException e) {
-            throw new NotFoundHomeException("Entity with id: " + getParameterValue("id", uriInfo)
-                .orElse("'not defined'") + " is not found");
+            throw new NotFoundHomeException(getMessage(e, uriInfo));
         }
         if (page.getTotalElements() == 1) {
             return page.getContent().get(0);

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
@@ -100,12 +100,7 @@ public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
                 .orElse(DefaultQueryParams.PAGE_NUMBER.getValue()));
         int pageSize = Integer.parseInt(getParameterValue(DefaultQueryParams.PAGE_SIZE.getParameter(), uriInfo)
                 .orElse(DefaultQueryParams.PAGE_SIZE.getValue()));
-        Page<D> page = service.findAll(pageNumber, pageSize, getSpecification(uriInfo));
-        if (page.getTotalElements() > 0) {
-            return page;
-        } else {
-            throw new NotFoundHomeException("No entities found by defined query");
-        }
+        return service.findAll(pageNumber, pageSize, getSpecification(uriInfo));
     }
 
     /**
@@ -117,15 +112,12 @@ public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
      * @throws IllegalStateException if number of Page elements more than 1
      */
     default D getOne(UriInfo uriInfo, QueryableService<T, D> service) {
-        Page<D> page;
-        try {
-            page = getPageFromQuery(uriInfo, service);
-        } catch (NotFoundHomeException e) {
-            throw new NotFoundHomeException("Entity with id: " + getParameterValue("id", uriInfo)
-                .orElse("'not defined'") + " is not found");
-        }
+        Page<D> page = getPageFromQuery(uriInfo, service);
         if (page.getTotalElements() == 1) {
             return page.getContent().get(0);
+        } else if (page.getTotalElements() == 0) {
+            throw new NotFoundHomeException("Entity with id: " + getParameterValue("id", uriInfo)
+                .orElse("'not defined'") + " is not found");
         } else {
             throw new IllegalStateException("Result of the request that require to return one element, "
                 + "contains more than one element");

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
@@ -108,12 +108,6 @@ public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
         }
     }
 
-    private static String getMessage(NotFoundHomeException e, UriInfo uriInfo) {
-        String entityName = e.getMessage().split(" ")[1];
-        return entityName + " with id: " + getParameterValue("id", uriInfo)
-            .orElse("'not defined'") + " is not found";
-    }
-
     /**
      * @param uriInfo - object that implements UriInfo interface
      *                  that provides access to application and request URI information
@@ -127,7 +121,8 @@ public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
         try {
             page = getPageFromQuery(uriInfo, service);
         } catch (NotFoundHomeException e) {
-            throw new NotFoundHomeException(getMessage(e, uriInfo));
+            throw new NotFoundHomeException("Entity with id: " + getParameterValue("id", uriInfo)
+                .orElse("'not defined'") + " is not found");
         }
         if (page.getTotalElements() == 1) {
             return page.getContent().get(0);

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
@@ -15,13 +15,13 @@ import javax.ws.rs.core.UriInfo;
 import com.softserveinc.ita.homeproject.homedata.entity.BaseEntity;
 import com.softserveinc.ita.homeproject.homeservice.dto.BaseDto;
 import com.softserveinc.ita.homeproject.homeservice.exception.BadRequestHomeException;
+import com.softserveinc.ita.homeproject.homeservice.exception.NotFoundHomeException;
 import com.softserveinc.ita.homeproject.homeservice.service.QueryableService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.domain.Specification;
 
 /**
  * QueryApiService - service that provides Spring Data Page by request query
- *
  * @author Oleksii Zinkevych
  * @param <T> - entity type
  * @param <D> - DTO type
@@ -32,11 +32,12 @@ public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
             .collect(Collectors.toMap(DefaultQueryParams::getParameter, DefaultQueryParams::getValue));
 
     /**
-     *
      * @param uriInfo - object that implements UriInfo interface
      *                  that provides access to application and request URI information
      * @return Map of query and path parameters required by EntitySpecificationService
      * to build Filter specification
+     * @throws BadRequestHomeException if uriInfo contains path and query params with the same name
+     * @throws BadRequestHomeException if uriInfo contains query params with more than one value
      */
     static MultivaluedMap<String, String> getFilterMap(UriInfo uriInfo) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
@@ -61,7 +62,6 @@ public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
     }
 
     /**
-     *
      * @param uriInfo - object that implements UriInfo interface
      *                  that provides access to application and request URI information
      * @return Spring Data Specification of entity
@@ -69,8 +69,7 @@ public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
     Specification<T> getSpecification(UriInfo uriInfo);
 
     /**
-     *
-     * @param param   - String name of query parameter
+     * @param param   - String name of query or path parameter
      * @param uriInfo - object that implements UriInfo interface
      *                  that provides access to application and request URI information
      * @return Optional of String value of specified query parameter
@@ -80,24 +79,54 @@ public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
             return Optional.of(uriInfo.getQueryParameters()
                     .get(param)
                     .get(0));
+        } else if (uriInfo.getPathParameters().get(param) != null) {
+            return Optional.of(uriInfo.getPathParameters()
+                    .get(param)
+                    .get(0));
         } else {
             return Optional.empty();
         }
     }
 
     /**
-     *
      * @param uriInfo - object that implements UriInfo interface
      *                  that provides access to application and request URI information
      * @param service - implementation of QueryableService interface
      * @return Spring Data Page of DTOs according to request query
+     * @throws NotFoundHomeException if number of Page elements less than 1
      */
     default Page<D> getPageFromQuery(UriInfo uriInfo, QueryableService<T, D> service) {
         int pageNumber = Integer.parseInt(getParameterValue(DefaultQueryParams.PAGE_NUMBER.getParameter(), uriInfo)
                 .orElse(DefaultQueryParams.PAGE_NUMBER.getValue()));
         int pageSize = Integer.parseInt(getParameterValue(DefaultQueryParams.PAGE_SIZE.getParameter(), uriInfo)
                 .orElse(DefaultQueryParams.PAGE_SIZE.getValue()));
-        return service.findAll(pageNumber, pageSize, getSpecification(uriInfo));
+        Page<D> page = service.findAll(pageNumber, pageSize, getSpecification(uriInfo));
+        if (page.getTotalElements() > 0) {
+            return page;
+        } else {
+            throw new NotFoundHomeException("No entities found by defined query");
+        }
+    }
+
+    /**
+     * @param uriInfo - object that implements UriInfo interface
+     *                  that provides access to application and request URI information
+     * @param service - implementation of QueryableService interface
+     * @return Single DTO
+     * @throws NotFoundHomeException if number of Page elements less than 1
+     * @throws IllegalStateException if number of Page elements more than 1
+     */
+    default D getOne(UriInfo uriInfo, QueryableService<T, D> service) {
+        Page<D> page = getPageFromQuery(uriInfo, service);
+        if (page.getTotalElements() == 1) {
+            return page.getContent().get(0);
+        } else if (page.getTotalElements() == 0) {
+            throw new NotFoundHomeException("Entity with id: " + getParameterValue("id", uriInfo)
+                    .orElse("'not defined'") + " is not found");
+        } else {
+            throw new IllegalStateException("Result of the request that required to return one element, "
+                    + "contains more than one element");
+        }
     }
 
     /**

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
@@ -117,15 +117,18 @@ public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
      * @throws IllegalStateException if number of Page elements more than 1
      */
     default D getOne(UriInfo uriInfo, QueryableService<T, D> service) {
-        Page<D> page = getPageFromQuery(uriInfo, service);
+        Page<D> page;
+        try {
+            page = getPageFromQuery(uriInfo, service);
+        } catch (NotFoundHomeException e) {
+            throw new NotFoundHomeException("Entity with id: " + getParameterValue("id", uriInfo)
+                .orElse("'not defined'") + " is not found");
+        }
         if (page.getTotalElements() == 1) {
             return page.getContent().get(0);
-        } else if (page.getTotalElements() == 0) {
-            throw new NotFoundHomeException("Entity with id: " + getParameterValue("id", uriInfo)
-                    .orElse("'not defined'") + " is not found");
         } else {
             throw new IllegalStateException("Result of the request that require to return one element, "
-                    + "contains more than one element");
+                + "contains more than one element");
         }
     }
 

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
@@ -124,7 +124,7 @@ public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
             throw new NotFoundHomeException("Entity with id: " + getParameterValue("id", uriInfo)
                     .orElse("'not defined'") + " is not found");
         } else {
-            throw new IllegalStateException("Result of the request that required to return one element, "
+            throw new IllegalStateException("Result of the request that require to return one element, "
                     + "contains more than one element");
         }
     }

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
@@ -103,6 +103,15 @@ public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
         return service.findAll(pageNumber, pageSize, getSpecification(uriInfo));
     }
 
+    private static String getMessage(UriInfo uriInfo) {
+        String message = "Entity with '%s' is not found";
+        MultivaluedMap<String, String> pathParams = uriInfo.getPathParameters();
+        String ids = pathParams.entrySet().stream()
+            .map(entry -> entry.getKey() + ": " + entry.getValue().get(0))
+            .collect(Collectors.joining(" and "));
+        return String.format(message, ids);
+    }
+
     /**
      * @param uriInfo - object that implements UriInfo interface
      *                  that provides access to application and request URI information
@@ -116,8 +125,7 @@ public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
         if (page.getTotalElements() == 1) {
             return page.getContent().get(0);
         } else if (page.getTotalElements() == 0) {
-            throw new NotFoundHomeException("Entity with id: " + getParameterValue("id", uriInfo)
-                .orElse("'not defined'") + " is not found");
+            throw new NotFoundHomeException(getMessage(uriInfo));
         } else {
             throw new IllegalStateException("Result of the request that require to return one element, "
                 + "contains more than one element");

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImpl.java
@@ -2,6 +2,7 @@ package com.softserveinc.ita.homeproject.application.service.impl;
 
 import javax.ws.rs.core.UriInfo;
 
+import com.softserveinc.ita.homeproject.application.service.EntitySpecificationService;
 import com.softserveinc.ita.homeproject.application.service.QueryApiService;
 import com.softserveinc.ita.homeproject.homedata.entity.BaseEntity;
 import com.softserveinc.ita.homeproject.homeservice.dto.BaseDto;
@@ -19,7 +20,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class QueryApiServiceImpl<T extends BaseEntity, D extends BaseDto> implements QueryApiService<T, D> {
-    private final EntitySpecificationServiceImpl<T> specificationService;
+    private final EntitySpecificationService<T> specificationService;
 
     @Override
     public Specification<T> getSpecification(UriInfo uriInfo) {

--- a/home-application/src/test/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImplTest.java
+++ b/home-application/src/test/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImplTest.java
@@ -1,0 +1,102 @@
+package com.softserveinc.ita.homeproject.application.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+import com.softserveinc.ita.homeproject.application.service.EntitySpecificationService;
+import com.softserveinc.ita.homeproject.application.service.QueryApiService;
+import com.softserveinc.ita.homeproject.homeservice.exception.BadRequestHomeException;
+import com.softserveinc.ita.homeproject.homeservice.service.QueryableService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SuppressWarnings({"rawtypes", "unchecked"})
+class QueryApiServiceImplTest {
+
+    @Mock
+    private static EntitySpecificationService entitySpecificationService;
+
+    @Mock
+    private static UriInfo uriInfo;
+
+    @Mock
+    private static QueryableService queryableService;
+
+    @Mock
+    private static Specification specification;
+
+    @InjectMocks
+    private QueryApiServiceImpl queryApiService;
+
+    @Test
+    public void getFilterMapTestWhenQueryOrPathParamsHaveTwoValues() {
+        when(uriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>() {{
+            put("cooperation_id", Arrays.asList("11", "11"));
+            put("user_id", Arrays.asList("11", "11"));
+        }});
+        when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>() {{
+            put("id", Arrays.asList("11", "11"));
+            put("size", Arrays.asList("11", "11"));
+        }});
+        assertThrows(BadRequestHomeException.class, () -> QueryApiService.getFilterMap(uriInfo));
+    }
+
+    @Test
+    public void getFilterMapTestWhenPathAndQueryParamsHaveTheSameName() {
+        when(uriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>() {{
+            put("id", Collections.singletonList("1"));
+        }});
+        when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>() {{
+            put("id", Collections.singletonList("1"));
+        }});
+        assertThrows(BadRequestHomeException.class, () -> QueryApiService.getFilterMap(uriInfo));
+    }
+
+    @Test
+    public void getParameterValueTest() {
+        when(uriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>() {{
+            put("id", Collections.singletonList("1"));
+            put("key2", Collections.singletonList("22"));
+        }});
+        when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>() {{
+            put("key3", Collections.singletonList("33"));
+            put("user_id", Collections.singletonList("4"));
+        }});
+        assertEquals("1", QueryApiService.getParameterValue("id", uriInfo).orElseThrow());
+        assertEquals("4", QueryApiService.getParameterValue("user_id", uriInfo).orElseThrow());
+    }
+
+    @Test
+    public void getOneTestWhenPageHaveMoreThanOneElement() {
+        when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>() {{
+            put("page_number", Collections.singletonList("1"));
+            put("page_size", Collections.singletonList("10"));
+            put("filter", Collections.singletonList("filter"));
+        }});
+        when(uriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>() {{
+            put("id", Collections.singletonList("1"));
+        }});
+        Page page = new PageImpl(Arrays.asList("1", "2", "3"));
+        when(entitySpecificationService.getSpecification(any(MultivaluedMap.class), anyString(), anyString()))
+            .thenReturn(specification);
+        when(queryableService.findAll(anyInt(), anyInt(), any(Specification.class))).thenReturn(page);
+        assertThrows(IllegalStateException.class, () -> queryApiService.getOne(uriInfo, queryableService));
+    }
+}

--- a/home-application/src/test/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImplTest.java
+++ b/home-application/src/test/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImplTest.java
@@ -46,7 +46,7 @@ class QueryApiServiceImplTest {
     private QueryApiServiceImpl queryApiService;
 
     @Test
-    public void getFilterMapTestWhenQueryOrPathParamsHaveTwoValues() {
+    void getFilterMapTestWhenQueryOrPathParamsHaveTwoValues() {
         when(uriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>() {{
             put("cooperation_id", Arrays.asList("11", "11"));
             put("user_id", Arrays.asList("11", "11"));
@@ -59,7 +59,7 @@ class QueryApiServiceImplTest {
     }
 
     @Test
-    public void getFilterMapTestWhenPathAndQueryParamsHaveTheSameName() {
+    void getFilterMapTestWhenPathAndQueryParamsHaveTheSameName() {
         when(uriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>() {{
             put("id", Collections.singletonList("1"));
         }});
@@ -70,7 +70,7 @@ class QueryApiServiceImplTest {
     }
 
     @Test
-    public void getParameterValueTest() {
+    void getParameterValueTest() {
         when(uriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>() {{
             put("id", Collections.singletonList("1"));
             put("key2", Collections.singletonList("22"));
@@ -84,7 +84,7 @@ class QueryApiServiceImplTest {
     }
 
     @Test
-    public void getOneTestWhenPageHaveMoreThanOneElement() {
+    void getOneTestWhenPageHaveMoreThanOneElement() {
         when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>() {{
             put("page_number", Collections.singletonList("1"));
             put("page_size", Collections.singletonList("10"));

--- a/home-open-api/src/main/resources/yaml/openapi.yaml
+++ b/home-open-api/src/main/resources/yaml/openapi.yaml
@@ -329,7 +329,7 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         default:
           $ref: '#/components/responses/InternalServerError'
-  /users/{user_id}:
+  /users/{id}:
     get:
       tags:
         - user
@@ -337,7 +337,7 @@ paths:
       description: The endpoint gets User by ID
       operationId: getUser
       parameters:
-        - name: "user_id"
+        - name: "id"
           in: "path"
           description: The ID of the User
           required: true
@@ -367,7 +367,7 @@ paths:
       description: The endpoint updates current User by ID
       operationId: updateUser
       parameters:
-        - name: "user_id"
+        - name: "id"
           in: "path"
           description: The ID of the User
           required: true
@@ -408,7 +408,7 @@ paths:
       description: The endpoint deletes User by ID
       operationId: deleteUser
       parameters:
-        - name: "user_id"
+        - name: "id"
           in: "path"
           description: The ID of the User
           required: true
@@ -552,7 +552,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         default:
           $ref: '#/components/responses/InternalServerError'
-  /users/{user_id}/contacts/{contact_id}:
+  /users/{user_id}/contacts/{id}:
     get:
       tags:
         - contact
@@ -569,7 +569,7 @@ paths:
             type: integer
             format: int64
             example: 1
-        - name: "contact_id"
+        - name: "id"
           in: "path"
           description: The ID of the Contact
           required: true
@@ -608,7 +608,7 @@ paths:
             type: integer
             format: int64
             example: 1
-        - name: "contact_id"
+        - name: "id"
           in: "path"
           description: The ID of the Contact
           required: true
@@ -656,7 +656,7 @@ paths:
             type: integer
             format: int64
             example: 1
-        - name: "contact_id"
+        - name: "id"
           in: "path"
           description: The ID of the Contact
           required: true
@@ -773,7 +773,7 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         default:
           $ref: '#/components/responses/InternalServerError'
-  /cooperation/{cooperation_id}:
+  /cooperation/{id}:
     get:
       tags:
         - cooperation
@@ -781,7 +781,7 @@ paths:
       description: The endpoint gets Cooperation by ID
       operationId: getCooperation
       parameters:
-        - name: "cooperation_id"
+        - name: "id"
           in: "path"
           description: The ID of the Cooperation
           required: true
@@ -811,7 +811,7 @@ paths:
       description: The endpoint updates current Cooperation by ID
       operationId: updateCooperation
       parameters:
-        - name: "cooperation_id"
+        - name: "id"
           in: "path"
           description: The ID of the Cooperation
           required: true
@@ -850,7 +850,7 @@ paths:
       description: The endpoint deletes Cooperation by ID
       operationId: deleteCooperation
       parameters:
-        - name: "cooperation_id"
+        - name: "id"
           in: "path"
           description: The ID of the Cooperation
           required: true
@@ -984,7 +984,7 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         default:
           $ref: '#/components/responses/InternalServerError'
-  /cooperation/{cooperation_id}/houses/{house_id}:
+  /cooperation/{cooperation_id}/houses/{id}:
     get:
       tags:
         - house
@@ -1001,7 +1001,7 @@ paths:
             type: integer
             format: int64
             example: 1
-        - name: "house_id"
+        - name: "id"
           in: "path"
           description: The ID of the House
           required: true
@@ -1040,7 +1040,7 @@ paths:
             type: integer
             format: int64
             example: 1
-        - name: "house_id"
+        - name: "id"
           in: "path"
           description: The ID of the House
           required: true
@@ -1088,7 +1088,7 @@ paths:
             type: integer
             format: int64
             example: 1
-        - name: "house_id"
+        - name: "id"
           in: "path"
           description: The ID of the House
           required: true

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/ContactService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/ContactService.java
@@ -11,7 +11,5 @@ public interface ContactService extends QueryableService<Contact, ContactDto> {
 
     ContactDto updateContact(Long id, ContactDto updateContactDto);
 
-    Page<ContactDto> findAll(Integer pageNumber, Integer pageSize, Specification<Contact> specification);
-
     void deactivateContact(Long id);
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/ContactService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/ContactService.java
@@ -2,8 +2,6 @@ package com.softserveinc.ita.homeproject.homeservice.service;
 
 import com.softserveinc.ita.homeproject.homedata.entity.Contact;
 import com.softserveinc.ita.homeproject.homeservice.dto.ContactDto;
-import org.springframework.data.domain.Page;
-import org.springframework.data.jpa.domain.Specification;
 
 public interface ContactService extends QueryableService<Contact, ContactDto> {
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/ContactService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/ContactService.java
@@ -13,7 +13,5 @@ public interface ContactService extends QueryableService<Contact, ContactDto> {
 
     Page<ContactDto> findAll(Integer pageNumber, Integer pageSize, Specification<Contact> specification);
 
-    ContactDto getContactById(Long id);
-
     void deactivateContact(Long id);
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/CooperationService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/CooperationService.java
@@ -13,7 +13,5 @@ public interface CooperationService extends QueryableService<Cooperation, Cooper
 
     Page<CooperationDto> findAll(Integer pageNumber, Integer pageSize, Specification<Cooperation> specification);
 
-    CooperationDto getCooperationById(Long id);
-
     void deactivateCooperation(Long id);
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/CooperationService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/CooperationService.java
@@ -11,7 +11,5 @@ public interface CooperationService extends QueryableService<Cooperation, Cooper
 
     CooperationDto updateCooperation(Long id, CooperationDto updateCooperationDto);
 
-    Page<CooperationDto> findAll(Integer pageNumber, Integer pageSize, Specification<Cooperation> specification);
-
     void deactivateCooperation(Long id);
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/CooperationService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/CooperationService.java
@@ -2,8 +2,6 @@ package com.softserveinc.ita.homeproject.homeservice.service;
 
 import com.softserveinc.ita.homeproject.homedata.entity.Cooperation;
 import com.softserveinc.ita.homeproject.homeservice.dto.CooperationDto;
-import org.springframework.data.domain.Page;
-import org.springframework.data.jpa.domain.Specification;
 
 public interface CooperationService extends QueryableService<Cooperation, CooperationDto> {
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/HouseService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/HouseService.java
@@ -2,8 +2,6 @@ package com.softserveinc.ita.homeproject.homeservice.service;
 
 import com.softserveinc.ita.homeproject.homedata.entity.House;
 import com.softserveinc.ita.homeproject.homeservice.dto.HouseDto;
-import org.springframework.data.domain.Page;
-import org.springframework.data.jpa.domain.Specification;
 
 public interface HouseService extends QueryableService<House, HouseDto> {
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/HouseService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/HouseService.java
@@ -11,8 +11,6 @@ public interface HouseService extends QueryableService<House, HouseDto> {
 
     HouseDto updateHouse(Long id, HouseDto updateHouseDto);
 
-    Page<HouseDto> findAll(Integer pageNumber, Integer pageSize, Specification<House> specification);
-
     void deactivateById(Long coopId, Long id);
 
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/HouseService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/HouseService.java
@@ -13,8 +13,6 @@ public interface HouseService extends QueryableService<House, HouseDto> {
 
     Page<HouseDto> findAll(Integer pageNumber, Integer pageSize, Specification<House> specification);
 
-    HouseDto getHouseById(Long coopId, Long id);
-
     void deactivateById(Long coopId, Long id);
 
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/NewsService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/NewsService.java
@@ -12,7 +12,5 @@ public interface NewsService extends QueryableService<News, NewsDto> {
 
     Page<NewsDto> findAll(Integer pageNumber, Integer pageSize, Specification<News> specification);
 
-    NewsDto getById(Long id);
-
     void deactivateNews(Long id);
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/NewsService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/NewsService.java
@@ -2,8 +2,6 @@ package com.softserveinc.ita.homeproject.homeservice.service;
 
 import com.softserveinc.ita.homeproject.homedata.entity.News;
 import com.softserveinc.ita.homeproject.homeservice.dto.NewsDto;
-import org.springframework.data.domain.Page;
-import org.springframework.data.jpa.domain.Specification;
 
 public interface NewsService extends QueryableService<News, NewsDto> {
     NewsDto create(NewsDto newsDto);

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/NewsService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/NewsService.java
@@ -10,7 +10,5 @@ public interface NewsService extends QueryableService<News, NewsDto> {
 
     NewsDto update(Long id, NewsDto newsDto);
 
-    Page<NewsDto> findAll(Integer pageNumber, Integer pageSize, Specification<News> specification);
-
     void deactivateNews(Long id);
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/UserService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/UserService.java
@@ -2,8 +2,6 @@ package com.softserveinc.ita.homeproject.homeservice.service;
 
 import com.softserveinc.ita.homeproject.homedata.entity.User;
 import com.softserveinc.ita.homeproject.homeservice.dto.UserDto;
-import org.springframework.data.domain.Page;
-import org.springframework.data.jpa.domain.Specification;
 
 public interface UserService extends QueryableService<User, UserDto> {
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/UserService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/UserService.java
@@ -13,7 +13,5 @@ public interface UserService extends QueryableService<User, UserDto> {
 
     Page<UserDto> findAll(Integer pageNumber, Integer pageSize, Specification<User> specification);
 
-    UserDto getUserById(Long id);
-
     void deactivateUser(Long id);
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/UserService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/UserService.java
@@ -11,7 +11,5 @@ public interface UserService extends QueryableService<User, UserDto> {
 
     UserDto updateUser(Long id, UserDto updateUserDto);
 
-    Page<UserDto> findAll(Integer pageNumber, Integer pageSize, Specification<User> specification);
-
     void deactivateUser(Long id);
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ContactServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ContactServiceImpl.java
@@ -105,7 +105,8 @@ public class ContactServiceImpl implements ContactService {
                                     Specification<Contact> specification) {
         Specification<Contact> contactSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        Page<ContactDto> page = contactRepository.findAll(contactSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        Page<ContactDto> page = contactRepository
+            .findAll(contactSpecification, PageRequest.of(pageNumber - 1, pageSize))
             .map(contact -> mapper.convert(contact, ContactDto.class));
         if (page.getTotalElements() > 0) {
             return page;

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ContactServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ContactServiceImpl.java
@@ -100,20 +100,13 @@ public class ContactServiceImpl implements ContactService {
         return mapper.convert(email, EmailContactDto.class);
     }
 
-    @Transactional
     @Override
     public Page<ContactDto> findAll(Integer pageNumber, Integer pageSize,
                                     Specification<Contact> specification) {
         Specification<Contact> contactSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        Page<ContactDto> page = contactRepository
-            .findAll(contactSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        return contactRepository.findAll(contactSpecification, PageRequest.of(pageNumber - 1, pageSize))
             .map(contact -> mapper.convert(contact, ContactDto.class));
-        if (page.getTotalElements() > 0) {
-            return page;
-        } else {
-            throw new NotFoundHomeException("No Contacts found by defined query");
-        }
     }
 
     @Override

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ContactServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ContactServiceImpl.java
@@ -105,15 +105,13 @@ public class ContactServiceImpl implements ContactService {
                                     Specification<Contact> specification) {
         Specification<Contact> contactSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        return contactRepository.findAll(contactSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        Page<ContactDto> page = contactRepository.findAll(contactSpecification, PageRequest.of(pageNumber - 1, pageSize))
             .map(contact -> mapper.convert(contact, ContactDto.class));
-    }
-
-    @Override
-    public ContactDto getContactById(Long id) {
-        Contact contactResponse = contactRepository.findById(id).filter(Contact::getEnabled)
-            .orElseThrow(() -> new NotFoundHomeException("Can't find contact with given ID:" + id));
-        return mapper.convert(contactResponse, ContactDto.class);
+        if (page.getTotalElements() > 0) {
+            return page;
+        } else {
+            throw new NotFoundHomeException("No Contacts found by defined query");
+        }
     }
 
     @Override

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ContactServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ContactServiceImpl.java
@@ -100,6 +100,7 @@ public class ContactServiceImpl implements ContactService {
         return mapper.convert(email, EmailContactDto.class);
     }
 
+    @Transactional
     @Override
     public Page<ContactDto> findAll(Integer pageNumber, Integer pageSize,
                                     Specification<Contact> specification) {

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 
 import com.softserveinc.ita.homeproject.homedata.entity.Cooperation;
 import com.softserveinc.ita.homeproject.homedata.repository.CooperationRepository;
-import com.softserveinc.ita.homeproject.homedata.repository.HouseRepository;
 import com.softserveinc.ita.homeproject.homeservice.dto.CooperationDto;
 import com.softserveinc.ita.homeproject.homeservice.exception.NotFoundHomeException;
 import com.softserveinc.ita.homeproject.homeservice.mapper.ServiceMapper;

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
@@ -2,10 +2,8 @@ package com.softserveinc.ita.homeproject.homeservice.service.impl;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
 import com.softserveinc.ita.homeproject.homedata.entity.Cooperation;
-import com.softserveinc.ita.homeproject.homedata.entity.House;
 import com.softserveinc.ita.homeproject.homedata.repository.CooperationRepository;
 import com.softserveinc.ita.homeproject.homedata.repository.HouseRepository;
 import com.softserveinc.ita.homeproject.homeservice.dto.CooperationDto;
@@ -29,8 +27,6 @@ public class CooperationServiceImpl implements CooperationService {
 
     private final ServiceMapper mapper;
 
-    private final HouseRepository houseRepository;
-
     @Transactional
     @Override
     public CooperationDto createCooperation(CooperationDto createCooperationDto) {
@@ -50,8 +46,8 @@ public class CooperationServiceImpl implements CooperationService {
     @Override
     public CooperationDto updateCooperation(Long id, CooperationDto updateCooperationDto) {
         Cooperation fromDb = cooperationRepository.findById(id)
-                .filter(Cooperation::getEnabled)
-                .orElseThrow(() -> new NotFoundHomeException(String.format(NOT_FOUND_COOPERATION_FORMAT, id)));
+            .filter(Cooperation::getEnabled)
+            .orElseThrow(() -> new NotFoundHomeException(String.format(NOT_FOUND_COOPERATION_FORMAT, id)));
 
         if (updateCooperationDto.getName() != null) {
             fromDb.setName(updateCooperationDto.getName());

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
@@ -70,23 +70,18 @@ public class CooperationServiceImpl implements CooperationService {
         return mapper.convert(fromDb, CooperationDto.class);
     }
 
-    @Transactional
     @Override
     public Page<CooperationDto> findAll(Integer pageNumber, Integer pageSize,
                                         Specification<Cooperation> specification) {
         Specification<Cooperation> cooperationSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        return cooperationRepository.findAll(cooperationSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        Page<CooperationDto> page = cooperationRepository.findAll(cooperationSpecification, PageRequest.of(pageNumber - 1, pageSize))
             .map(cooperation -> mapper.convert(cooperation, CooperationDto.class));
-    }
-
-    @Override
-    public CooperationDto getCooperationById(Long id) {
-        Cooperation toGet = cooperationRepository.findById(id).filter(Cooperation::getEnabled)
-            .orElseThrow(() -> new NotFoundHomeException(String.format(NOT_FOUND_COOPERATION_FORMAT, id)));
-        List<House> houseList = houseRepository.findHousesByCooperationId(toGet.getId());
-        toGet.setHouses(houseList);
-        return mapper.convert(toGet, CooperationDto.class);
+        if (page.getTotalElements() > 0) {
+            return page;
+        } else {
+            throw new NotFoundHomeException("No Cooperations found by defined query");
+        }
     }
 
     @Override

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
@@ -76,14 +76,8 @@ public class CooperationServiceImpl implements CooperationService {
                                         Specification<Cooperation> specification) {
         Specification<Cooperation> cooperationSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        Page<CooperationDto> page = cooperationRepository
-            .findAll(cooperationSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        return cooperationRepository.findAll(cooperationSpecification, PageRequest.of(pageNumber - 1, pageSize))
             .map(cooperation -> mapper.convert(cooperation, CooperationDto.class));
-        if (page.getTotalElements() > 0) {
-            return page;
-        } else {
-            throw new NotFoundHomeException("No Cooperations found by defined query");
-        }
     }
 
     @Override

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
@@ -75,7 +75,8 @@ public class CooperationServiceImpl implements CooperationService {
                                         Specification<Cooperation> specification) {
         Specification<Cooperation> cooperationSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        Page<CooperationDto> page = cooperationRepository.findAll(cooperationSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        Page<CooperationDto> page = cooperationRepository
+            .findAll(cooperationSpecification, PageRequest.of(pageNumber - 1, pageSize))
             .map(cooperation -> mapper.convert(cooperation, CooperationDto.class));
         if (page.getTotalElements() > 0) {
             return page;

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
@@ -70,6 +70,7 @@ public class CooperationServiceImpl implements CooperationService {
         return mapper.convert(fromDb, CooperationDto.class);
     }
 
+    @Transactional
     @Override
     public Page<CooperationDto> findAll(Integer pageNumber, Integer pageSize,
                                         Specification<Cooperation> specification) {

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/HouseServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/HouseServiceImpl.java
@@ -68,25 +68,18 @@ public class HouseServiceImpl implements HouseService {
         return mapper.convert(fromDb, HouseDto.class);
     }
 
-    @Transactional
     @Override
     public Page<HouseDto> findAll(Integer pageNumber, Integer pageSize, Specification<House> specification) {
         Specification<House> houseSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        return houseRepository.findAll(houseSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        Page<HouseDto> page = houseRepository.findAll(houseSpecification, PageRequest.of(pageNumber - 1, pageSize))
             .map(house -> mapper.convert(house, HouseDto.class));
-    }
-
-    @Override
-    public HouseDto getHouseById(Long coopId, Long id) {
-        House toGet = houseRepository.findById(id).filter(House::getEnabled)
-            .orElseThrow(() -> new NotFoundHomeException(String.format(HOUSE_WITH_ID_NOT_FOUND, id)));
-        if (!toGet.getCooperation().getId().equals(coopId)) {
-            throw new NotFoundHomeException(String.format(HOUSE_WITH_ID_NOT_FOUND, id));
+        if (page.getTotalElements() > 0) {
+            return page;
+        } else {
+            throw new NotFoundHomeException("No Houses found by defined query");
         }
-        return mapper.convert(toGet, HouseDto.class);
     }
-
 
     @Override
     public void deactivateById(Long coopId, Long id) {

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/HouseServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/HouseServiceImpl.java
@@ -69,6 +69,7 @@ public class HouseServiceImpl implements HouseService {
     }
 
     @Override
+    @Transactional
     public Page<HouseDto> findAll(Integer pageNumber, Integer pageSize, Specification<House> specification) {
         Specification<House> houseSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/HouseServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/HouseServiceImpl.java
@@ -68,18 +68,13 @@ public class HouseServiceImpl implements HouseService {
         return mapper.convert(fromDb, HouseDto.class);
     }
 
-    @Override
     @Transactional
+    @Override
     public Page<HouseDto> findAll(Integer pageNumber, Integer pageSize, Specification<House> specification) {
         Specification<House> houseSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        Page<HouseDto> page = houseRepository.findAll(houseSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        return houseRepository.findAll(houseSpecification, PageRequest.of(pageNumber - 1, pageSize))
             .map(house -> mapper.convert(house, HouseDto.class));
-        if (page.getTotalElements() > 0) {
-            return page;
-        } else {
-            throw new NotFoundHomeException("No Houses found by defined query");
-        }
     }
 
     @Override

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/NewsServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/NewsServiceImpl.java
@@ -75,16 +75,13 @@ public class NewsServiceImpl implements NewsService {
     public Page<NewsDto> findAll(Integer pageNumber, Integer pageSize, Specification<News> specification) {
         Specification<News> newsSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        return newsRepository.findAll(newsSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        Page<NewsDto> page = newsRepository.findAll(newsSpecification, PageRequest.of(pageNumber - 1, pageSize))
             .map(news -> mapper.convert(news, NewsDto.class));
-    }
-
-    @Override
-    public NewsDto getById(Long id) {
-        News newsResponse = newsRepository.findById(id).filter(News::getEnabled)
-            .orElseThrow(() -> new NotFoundHomeException(String.format(FORMAT, NOT_FOUND_NEWS, id)));
-
-        return mapper.convert(newsResponse, NewsDto.class);
+        if (page.getTotalElements() > 0) {
+            return page;
+        } else {
+            throw new NotFoundHomeException("No News found by defined query");
+        }
     }
 
     @Override

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/NewsServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/NewsServiceImpl.java
@@ -72,6 +72,7 @@ public class NewsServiceImpl implements NewsService {
     }
 
     @Override
+    @Transactional
     public Page<NewsDto> findAll(Integer pageNumber, Integer pageSize, Specification<News> specification) {
         Specification<News> newsSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/NewsServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/NewsServiceImpl.java
@@ -72,17 +72,11 @@ public class NewsServiceImpl implements NewsService {
     }
 
     @Override
-    @Transactional
     public Page<NewsDto> findAll(Integer pageNumber, Integer pageSize, Specification<News> specification) {
         Specification<News> newsSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        Page<NewsDto> page = newsRepository.findAll(newsSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        return newsRepository.findAll(newsSpecification, PageRequest.of(pageNumber - 1, pageSize))
             .map(news -> mapper.convert(news, NewsDto.class));
-        if (page.getTotalElements() > 0) {
-            return page;
-        } else {
-            throw new NotFoundHomeException("No News found by defined query");
-        }
     }
 
     @Override

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserServiceImpl.java
@@ -92,13 +92,8 @@ public class UserServiceImpl implements UserService {
     public Page<UserDto> findAll(Integer pageNumber, Integer pageSize, Specification<User> specification) {
         Specification<User> userSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        Page<UserDto> page = userRepository.findAll(userSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        return userRepository.findAll(userSpecification, PageRequest.of(pageNumber - 1, pageSize))
             .map(user -> mapper.convert(user, UserDto.class));
-        if (page.getTotalElements() > 0) {
-            return page;
-        } else {
-            throw new NotFoundHomeException("No Users found by defined query");
-        }
     }
 
     @Override

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserServiceImpl.java
@@ -88,20 +88,16 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    @Transactional
     public Page<UserDto> findAll(Integer pageNumber, Integer pageSize, Specification<User> specification) {
         Specification<User> userSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        return userRepository.findAll(userSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        Page<UserDto> page = userRepository.findAll(userSpecification, PageRequest.of(pageNumber - 1, pageSize))
             .map(user -> mapper.convert(user, UserDto.class));
-    }
-
-    @Override
-    @Transactional
-    public UserDto getUserById(Long id) {
-        User toGet = userRepository.findById(id).filter(User::getEnabled)
-            .orElseThrow(() -> new NotFoundHomeException(String.format(USER_NOT_FOUND_FORMAT, id)));
-        return mapper.convert(toGet, UserDto.class);
+        if (page.getTotalElements() > 0) {
+            return page;
+        } else {
+            throw new NotFoundHomeException("No Users found by defined query");
+        }
     }
 
     @Override

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserServiceImpl.java
@@ -88,6 +88,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
     public Page<UserDto> findAll(Integer pageNumber, Integer pageSize, Specification<User> specification) {
         Specification<User> userSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/202)


## Code reviewers

- [ ]  @@kh0ma, @VadymSokorenko, @denis-litvinov, @likeRewca, @Abhai2016, @Ilya-Ross, @annaprok

### Second Level Review

- [ ] @github_username

## Summary of issue

The existing functionality was not reused

## Summary of change

- added getOne method to QueryApiService
- changed controllers to use getOne method of QueryApiService for getOne operations
- deleted getOne methods in entity services as unused
- fixed tests according to new exception messages

## Testing approach

Automation

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
