### PR TITLE
Issue#213 Refactor QueryApiService and API implementation, Issue#218 Reuse findAll operation for getOne operation in entity services

### DIFF
--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartments/ApartmentApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartments/ApartmentApiIT.java
@@ -46,7 +46,7 @@ class ApartmentApiIT {
     }
 
     @Test
-    void createApartmentWithNonExistentHouse() throws ApiException{
+    void createApartmentWithNonExistentHouse() {
         CreateApartment createApartment = createApartment();
 
         Long wrongId = 1000000L;
@@ -83,7 +83,7 @@ class ApartmentApiIT {
                 .isThrownBy(() -> apartmentApi
                         .getApartmentWithHttpInfo(expectedHouse.getId(), wrongId))
                 .matches(exception -> exception.getCode() == NOT_FOUND)
-                .withMessageContaining("Can't find apartment with given ID: " + wrongId);
+            .withMessageContaining("Apartment with 'id: " + wrongId + "' is not found");
     }
 
     @Test
@@ -100,7 +100,7 @@ class ApartmentApiIT {
                 .isThrownBy(() -> apartmentApi
                         .getApartmentWithHttpInfo(wrongId, expectedApartment.getId()))
                 .matches(exception -> exception.getCode() == NOT_FOUND)
-                .withMessageContaining("Can't find house with given ID: " + wrongId);
+            .withMessageContaining("Apartment with 'id: " + expectedApartment.getId() + "' is not found");
     }
 
     @Test

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/ContactApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/ContactApiIT.java
@@ -188,7 +188,7 @@ class ContactApiIT {
                 .getContactOnUserWithHttpInfo(expectedUser.getId(), wrongId))
             .matches(exception -> exception.getCode() == NOT_FOUND)
             .withMessageContaining(
-                "Entity with 'user_id: " + expectedUser.getId() + " and id: " + wrongId + "' is not found");
+                "Contact with 'id: " + wrongId + "' is not found");
     }
 
     @Test

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/contacts/CooperationContactApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/contacts/CooperationContactApiIT.java
@@ -311,7 +311,7 @@ class CooperationContactApiIT {
     }
 
     @Test
-    void passNullIdWhenDeleteAnyContactTest() throws ApiException {
+    void deletingNonExistentAnyContactTest() throws ApiException {
         ReadCooperation expectedCooperation = cooperationApi.createCooperation(createCooperation());
         Long wrongId = 10000L;
 
@@ -323,7 +323,7 @@ class CooperationContactApiIT {
     }
 
     @Test
-    void passNullContactIdWhenDeleteAnyContactTest() throws ApiException {
+    void passNullIdWhenDeleteAnyContactTest() throws ApiException {
         ReadCooperation expectedUser = cooperationApi.createCooperation(createCooperation());
 
         assertThatExceptionOfType(ApiException.class)

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/contacts/CooperationContactApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/contacts/CooperationContactApiIT.java
@@ -309,7 +309,7 @@ class CooperationContactApiIT {
     }
 
     @Test
-    void deletingNonExistentAnyContactTest() throws ApiException {
+    void passNullIdWhenDeleteAnyContactTest() throws ApiException {
         ReadCooperation expectedCooperation = cooperationApi.createCooperation(createCooperation());
         Long wrongId = 10000L;
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/contacts/CooperationContactApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/contacts/CooperationContactApiIT.java
@@ -91,7 +91,7 @@ class CooperationContactApiIT {
             .isThrownBy(() -> cooperationContactApi
                 .getContactOnCooperation(expectedCooperation.getId(), wrongId))
             .matches(exception -> exception.getCode() == NOT_FOUND)
-            .withMessageContaining("Can't find contact with given ID:" + wrongId);
+            .withMessageContaining("Contact with 'id: " + wrongId + "' is not found");
     }
 
     @Test
@@ -287,7 +287,7 @@ class CooperationContactApiIT {
         assertThatExceptionOfType(ApiException.class).isThrownBy(() -> cooperationContactApi
             .getContactOnCooperationWithHttpInfo(cooperation.getId(), savedEmailContact.getId()))
             .matches(exception -> exception.getCode() == NOT_FOUND)
-            .withMessageContaining("Can't find contact with given ID");
+            .withMessageContaining("Contact with 'id: " + savedEmailContact.getId() + "' is not found");
     }
 
     @Test

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/contacts/CooperationContactApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/contacts/CooperationContactApiIT.java
@@ -1,5 +1,17 @@
 package com.softserveinc.ita.homeproject.api.tests.cooperations.contacts;
 
+import static com.softserveinc.ita.homeproject.api.tests.utils.ApiClientUtil.BAD_REQUEST;
+import static com.softserveinc.ita.homeproject.api.tests.utils.ApiClientUtil.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.core.Response;
+
 import com.softserveinc.ita.homeproject.ApiException;
 import com.softserveinc.ita.homeproject.ApiResponse;
 import com.softserveinc.ita.homeproject.api.CooperationApi;
@@ -7,30 +19,20 @@ import com.softserveinc.ita.homeproject.api.CooperationContactApi;
 import com.softserveinc.ita.homeproject.api.tests.utils.ApiClientUtil;
 import com.softserveinc.ita.homeproject.model.Address;
 import com.softserveinc.ita.homeproject.model.ContactType;
+import com.softserveinc.ita.homeproject.model.CreateContact;
 import com.softserveinc.ita.homeproject.model.CreateCooperation;
 import com.softserveinc.ita.homeproject.model.CreateEmailContact;
-import com.softserveinc.ita.homeproject.model.CreatePhoneContact;
 import com.softserveinc.ita.homeproject.model.CreateHouse;
+import com.softserveinc.ita.homeproject.model.CreatePhoneContact;
 import com.softserveinc.ita.homeproject.model.ReadContact;
+import com.softserveinc.ita.homeproject.model.ReadCooperation;
 import com.softserveinc.ita.homeproject.model.ReadEmailContact;
 import com.softserveinc.ita.homeproject.model.ReadPhoneContact;
 import com.softserveinc.ita.homeproject.model.UpdateContact;
 import com.softserveinc.ita.homeproject.model.UpdateEmailContact;
 import com.softserveinc.ita.homeproject.model.UpdatePhoneContact;
-import com.softserveinc.ita.homeproject.model.ReadCooperation;
-import com.softserveinc.ita.homeproject.model.CreateContact;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
-
-import javax.ws.rs.core.Response;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.softserveinc.ita.homeproject.api.tests.utils.ApiClientUtil.BAD_REQUEST;
-import static com.softserveinc.ita.homeproject.api.tests.utils.ApiClientUtil.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.jupiter.api.Assertions.*;
 
 class CooperationContactApiIT {
 
@@ -305,7 +307,7 @@ class CooperationContactApiIT {
             .isThrownBy(() -> cooperationContactApi
                 .getContactOnCooperationWithHttpInfo(cooperation.getId(), savedPhoneContact.getId()))
             .matches(exception -> exception.getCode() == NOT_FOUND)
-            .withMessageContaining("Can't find contact with given ID");
+            .withMessageContaining("Contact with 'id: " + savedPhoneContact.getId() + "' is not found");
     }
 
     @Test
@@ -321,7 +323,7 @@ class CooperationContactApiIT {
     }
 
     @Test
-    void passNullIdWhenDeleteAnyContactTest() throws ApiException {
+    void passNullContactIdWhenDeleteAnyContactTest() throws ApiException {
         ReadCooperation expectedUser = cooperationApi.createCooperation(createCooperation());
 
         assertThatExceptionOfType(ApiException.class)

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/news/NewsApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/news/NewsApiIT.java
@@ -237,7 +237,7 @@ class NewsApiIT {
         assertThatExceptionOfType(ApiException.class)
             .isThrownBy(() -> newsApi.getNewsWithHttpInfo(wrongId))
             .matches(exception -> exception.getCode() == NOT_FOUND)
-            .withMessageContaining("Entity with 'id: " + wrongId + "' is not found");
+            .withMessageContaining("News with 'id: " + wrongId + "' is not found");
     }
 
     @Test

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/UserApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/UserApiIT.java
@@ -225,7 +225,7 @@ class UserApiIT {
         assertThatExceptionOfType(ApiException.class)
             .isThrownBy(() -> userApi.getUserWithHttpInfo(userId))
             .matches(exception -> exception.getCode() == NOT_FOUND)
-            .withMessageContaining("Entity with 'id: " + userId + "' is not found");
+            .withMessageContaining("User with 'id: " + userId + "' is not found");
     }
 
     @Test

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CommonApi.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CommonApi.java
@@ -12,6 +12,7 @@ import com.softserveinc.ita.homeproject.homeservice.dto.BaseDto;
 import com.softserveinc.ita.homeproject.model.BaseReadView;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.domain.Specification;
 
 public abstract class CommonApi {
 
@@ -22,15 +23,15 @@ public abstract class CommonApi {
     public static final String PAGING_TOTAL_COUNT = "Paging-total-count";
 
     @Context
-    protected UriInfo uriInfo;
+    private UriInfo uriInfo;
 
     @Autowired
     protected HomeMapper mapper;
 
     @Autowired
-    protected QueryApiService queryApiService;
+    private QueryApiService queryApiService;
 
-    protected <T extends BaseDto> Response buildQueryResponse(Page<T> page, Class<? extends BaseReadView> clazz) {
+    protected <D extends BaseDto> Response buildQueryResponse(Page<D> page, Class<? extends BaseReadView> clazz) {
         long totalElements = page.getTotalElements();
         int totalPages = page.getTotalPages();
         int numberOfElements = page.getNumberOfElements();

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CommonApi.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CommonApi.java
@@ -14,13 +14,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.domain.Specification;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class CommonApi {
 
-    public static final String PAGING_COUNT = "Paging-count";
+    private static final String PAGING_COUNT = "Paging-count";
 
-    public static final String PAGING_TOTAL_PAGES = "Paging-total-pages";
+    private static final String PAGING_TOTAL_PAGES = "Paging-total-pages";
 
-    public static final String PAGING_TOTAL_COUNT = "Paging-total-count";
+    private static final String PAGING_TOTAL_COUNT = "Paging-total-count";
 
     @Context
     private UriInfo uriInfo;
@@ -46,5 +47,9 @@ public abstract class CommonApi {
             .header(PAGING_TOTAL_PAGES, totalPages)
             .header(PAGING_TOTAL_COUNT, totalElements)
             .build();
+    }
+
+    protected <T> Specification<T> getSpecification() {
+        return queryApiService.getSpecification(uriInfo);
     }
 }

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CooperationApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CooperationApiImpl.java
@@ -134,12 +134,12 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
 
     @PreAuthorize(GET_HOUSES_PERMISSION)
     @Override
-    public Response queryHouse(@Min(1) Long cooperationId,
+    public Response queryHouse(Long cooperationId,
                                @Min(1) Integer pageNumber,
                                @Min(1) @Max(10) Integer pageSize,
                                String sort,
                                String filter,
-                               Long houseId,
+                               Long id,
                                Integer quantityFlat,
                                Integer adjoiningArea,
                                BigDecimal houseArea) {
@@ -153,12 +153,13 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
     public Response queryContactsOnCooperation(Long cooperationId,
                                                @Min(1) Integer pageNumber,
                                                @Min(1) @Max(10) Integer pageSize,
-                                               String sort,
-                                               String filter,
-                                               String id, String phone,
+                                               String sort, String filter,
+                                               Long id,
+                                               String phone,
                                                String email,
                                                String main,
                                                String type) {
+
         Page<ContactDto> readContact = contactService.findAll(pageNumber, pageSize, getSpecification());
         return buildQueryResponse(readContact, ReadContact.class);
     }

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CooperationApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CooperationApiImpl.java
@@ -110,8 +110,8 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
 
     @PreAuthorize(GET_COOP_CONTACT_PERMISSION)
     @Override
-    public Response getContactOnCooperation(Long cooperationId, Long contactId) {
-        ContactDto readContactDto = contactService.getOne(contactId);
+    public Response getContactOnCooperation(Long cooperationId, Long id) {
+        var readContactDto = contactService.getOne(id);
         var readContact = mapper.convert(readContactDto, ReadContact.class);
 
         return Response.status(Response.Status.OK).entity(readContact).build();

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CooperationApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CooperationApiImpl.java
@@ -91,8 +91,8 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
 
     @PreAuthorize(GET_COOPERATION_PERMISSION)
     @Override
-    public Response getCooperation(Long cooperationId) {
-        CooperationDto readCoopDto = cooperationService.getOne(cooperationId);
+    public Response getCooperation(Long id) {
+        CooperationDto readCoopDto = cooperationService.getOne(id);
         ReadCooperation readCoop = mapper.convert(readCoopDto, ReadCooperation.class);
 
         return Response.status(Response.Status.OK).entity(readCoop).build();
@@ -101,8 +101,8 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
 
     @PreAuthorize(GET_HOUSE_PERMISSION)
     @Override
-    public Response getHouse(Long cooperationId, Long houseId) {
-        HouseDto toGet = houseService.getOne(houseId);
+    public Response getHouse(Long cooperationId, Long id) {
+        HouseDto toGet = houseService.getOne(id);
         ReadHouse readHouse = mapper.convert(toGet, ReadHouse.class);
 
         return Response.status(Response.Status.OK).entity(readHouse).build();
@@ -153,43 +153,43 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
     public Response queryContactsOnCooperation(Long cooperationId,
                                                @Min(1) Integer pageNumber,
                                                @Min(1) @Max(10) Integer pageSize,
-                                               String sort, String filter,
+                                               String sort,
+                                               String filter,
                                                Long id,
                                                String phone,
                                                String email,
                                                String main,
                                                String type) {
-
         Page<ContactDto> readContact = contactService.findAll(pageNumber, pageSize, getSpecification());
         return buildQueryResponse(readContact, ReadContact.class);
     }
 
     @PreAuthorize(DELETE_COOPERATION_PERMISSION)
     @Override
-    public Response deleteCooperation(Long cooperationId) {
-        cooperationService.deactivateCooperation(cooperationId);
+    public Response deleteCooperation(Long id) {
+        cooperationService.deactivateCooperation(id);
         return Response.status(Response.Status.NO_CONTENT).build();
     }
 
     @PreAuthorize(DELETE_HOUSE_PERMISSION)
     @Override
-    public Response deleteHouse(Long cooperationId, Long houseId) {
-        houseService.deactivateById(cooperationId, houseId);
+    public Response deleteHouse(Long cooperationId, Long id) {
+        houseService.deactivateById(cooperationId, id);
         return Response.status(Response.Status.NO_CONTENT).build();
     }
 
     @PreAuthorize(DELETE_COOP_CONTACT_PERMISSION)
     @Override
-    public Response deleteContactOnCooperation(Long cooperationId, Long contactId) {
-        contactService.deactivateContact(contactId);
+    public Response deleteContactOnCooperation(Long cooperationId, Long id) {
+        contactService.deactivateContact(id);
         return Response.status(Response.Status.NO_CONTENT).build();
     }
 
     @PreAuthorize(UPDATE_COOPERATION_PERMISSION)
     @Override
-    public Response updateCooperation(Long cooperationId, @Valid UpdateCooperation updateCooperation) {
+    public Response updateCooperation(Long id, @Valid UpdateCooperation updateCooperation) {
         CooperationDto updateCoopDto = mapper.convert(updateCooperation, CooperationDto.class);
-        CooperationDto toUpdate = cooperationService.updateCooperation(cooperationId, updateCoopDto);
+        CooperationDto toUpdate = cooperationService.updateCooperation(id, updateCoopDto);
         ReadCooperation readCooperation = mapper.convert(toUpdate, ReadCooperation.class);
 
         return Response.status(Response.Status.OK).entity(readCooperation).build();
@@ -197,9 +197,9 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
 
     @PreAuthorize(UPDATE_HOUSE_PERMISSION)
     @Override
-    public Response updateHouse(Long cooperationId, Long houseId, @Valid UpdateHouse updateHouse) {
+    public Response updateHouse(Long cooperationId, Long id, @Valid UpdateHouse updateHouse) {
         HouseDto updateHouseDto = mapper.convert(updateHouse, HouseDto.class);
-        HouseDto toUpdate = houseService.updateHouse(houseId, updateHouseDto);
+        HouseDto toUpdate = houseService.updateHouse(id, updateHouseDto);
         ReadHouse readHouse = mapper.convert(toUpdate, ReadHouse.class);
 
         return Response.status(Response.Status.OK).entity(readHouse).build();
@@ -207,9 +207,9 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
 
     @PreAuthorize(UPDATE_COOP_CONTACT_PERMISSION)
     @Override
-    public Response updateContactOnCooperation(Long cooperationId, Long contactId, @Valid UpdateContact updateContact) {
+    public Response updateContactOnCooperation(Long cooperationId, Long id, @Valid UpdateContact updateContact) {
         var updateContactDto = mapper.convert(updateContact, ContactDto.class);
-        var updatedContactDto = contactService.updateContact(cooperationId, contactId, updateContactDto);
+        var updatedContactDto = contactService.updateContact(cooperationId, id, updateContactDto);
         var readContact = mapper.convert(updatedContactDto, ReadContact.class);
 
         return Response.status(Response.Status.OK).entity(readContact).build();

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CooperationApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CooperationApiImpl.java
@@ -92,7 +92,7 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
     @PreAuthorize(GET_COOPERATION_PERMISSION)
     @Override
     public Response getCooperation(Long cooperationId) {
-        CooperationDto readCoopDto = (CooperationDto) queryApiService.getOne(uriInfo, cooperationService);
+        CooperationDto readCoopDto = cooperationService.getOne(cooperationId);
         ReadCooperation readCoop = mapper.convert(readCoopDto, ReadCooperation.class);
 
         return Response.status(Response.Status.OK).entity(readCoop).build();
@@ -102,7 +102,7 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
     @PreAuthorize(GET_HOUSE_PERMISSION)
     @Override
     public Response getHouse(Long cooperationId, Long houseId) {
-        HouseDto toGet = (HouseDto) queryApiService.getOne(uriInfo, houseService);
+        HouseDto toGet = houseService.getOne(houseId);
         ReadHouse readHouse = mapper.convert(toGet, ReadHouse.class);
 
         return Response.status(Response.Status.OK).entity(readHouse).build();
@@ -111,7 +111,7 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
     @PreAuthorize(GET_COOP_CONTACT_PERMISSION)
     @Override
     public Response getContactOnCooperation(Long cooperationId, Long contactId) {
-        var readContactDto = contactService.getContactById(contactId);
+        ContactDto readContactDto = contactService.getOne(contactId);
         var readContact = mapper.convert(readContactDto, ReadContact.class);
 
         return Response.status(Response.Status.OK).entity(readContact).build();
@@ -128,7 +128,7 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
                                      String iban,
                                      String usreo) {
 
-        Page<CooperationDto> readCooperation = queryApiService.getPageFromQuery(uriInfo, cooperationService);
+        Page<CooperationDto> readCooperation = cooperationService.findAll(pageNumber, pageSize, getSpecification());
         return buildQueryResponse(readCooperation, ReadCooperation.class);
     }
 
@@ -144,7 +144,7 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
                                Integer adjoiningArea,
                                BigDecimal houseArea) {
 
-        Page<HouseDto> readHouse = queryApiService.getPageFromQuery(uriInfo, houseService);
+        Page<HouseDto> readHouse = houseService.findAll(pageNumber, pageSize, getSpecification());
         return buildQueryResponse(readHouse, ReadHouse.class);
     }
 
@@ -159,7 +159,7 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
                                                String email,
                                                String main,
                                                String type) {
-        Page<ContactDto> readContact = queryApiService.getPageFromQuery(uriInfo, contactService);
+        Page<ContactDto> readContact = contactService.findAll(pageNumber, pageSize, getSpecification());
         return buildQueryResponse(readContact, ReadContact.class);
     }
 

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CooperationApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/CooperationApiImpl.java
@@ -103,7 +103,7 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
     @PreAuthorize(GET_HOUSE_PERMISSION)
     @Override
     public Response getHouse(Long cooperationId, Long id) {
-        HouseDto toGet = houseService.getOne(id);
+        HouseDto toGet = houseService.getOne(id, getSpecification());
         ReadHouse readHouse = mapper.convert(toGet, ReadHouse.class);
 
         return Response.status(Response.Status.OK).entity(readHouse).build();
@@ -112,7 +112,7 @@ public class CooperationApiImpl extends CommonApi implements CooperationApi {
     @PreAuthorize(GET_COOP_CONTACT_PERMISSION)
     @Override
     public Response getContactOnCooperation(Long cooperationId, Long id) {
-        var readContactDto = contactService.getOne(id);
+        var readContactDto = contactService.getOne(id, getSpecification());
         var readContact = mapper.convert(readContactDto, ReadContact.class);
 
         return Response.status(Response.Status.OK).entity(readContact).build();

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/HouseApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/HouseApiImpl.java
@@ -46,7 +46,7 @@ public class HouseApiImpl extends CommonApi implements HousesApi {
     @PreAuthorize(GET_APARTMENT_PERMISSION)
     @Override
     public Response getApartment(Long houseId, Long id) {
-        ApartmentDto toGet = apartmentService.getApartmentById(houseId, id);
+        ApartmentDto toGet = apartmentService.getOne(id, getSpecification());
         var readApartment = mapper.convert(toGet, ReadApartment.class);
 
         return Response.status(Response.Status.OK).entity(readApartment).build();

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/HouseApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/HouseApiImpl.java
@@ -63,7 +63,7 @@ public class HouseApiImpl extends CommonApi implements HousesApi {
                                    String apartmentNumber,
                                    BigDecimal apartmentArea) {
 
-        Page<ApartmentDto> readApartment = queryApiService.getPageFromQuery(uriInfo, apartmentService);
+        Page<ApartmentDto> readApartment = apartmentService.findAll(pageNumber, pageSize, getSpecification());
         return buildQueryResponse(readApartment, ReadApartment.class);
     }
 

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/NewsApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/NewsApiImpl.java
@@ -48,7 +48,6 @@ public class NewsApiImpl extends CommonApi implements NewsApi {
         NewsDto newsDto = mapper.convert(createNews, NewsDto.class);
         NewsDto createdNewsDto = newsService.create(newsDto);
         ReadNews response = mapper.convert(createdNewsDto, ReadNews.class);
-
         return Response.status(Response.Status.CREATED).entity(response).build();
     }
 
@@ -76,7 +75,6 @@ public class NewsApiImpl extends CommonApi implements NewsApi {
      */
     @PreAuthorize(GET_NEWS_PERMISSION)
     @Override
-    @SuppressWarnings("unchecked")
     public Response getAllNews(@Min(1) Integer pageNumber,
                                @Min(1) @Max(10) Integer pageSize,
                                String sort,
@@ -86,7 +84,7 @@ public class NewsApiImpl extends CommonApi implements NewsApi {
                                String text,
                                String source) {
 
-        Page<NewsDto> readNews = queryApiService.getPageFromQuery(uriInfo, newsService);
+        Page<NewsDto> readNews = newsService.findAll(pageNumber, pageSize, getSpecification());
         return buildQueryResponse(readNews, ReadNews.class);
     }
 
@@ -100,9 +98,8 @@ public class NewsApiImpl extends CommonApi implements NewsApi {
     @PreAuthorize(GET_NEWS_PERMISSION)
     @Override
     public Response getNews(Long id) {
-        NewsDto readNewsDto = (NewsDto) queryApiService.getOne(uriInfo, newsService);
+        NewsDto readNewsDto = newsService.getOne(id);
         ReadNews newsApiResponse = mapper.convert(readNewsDto, ReadNews.class);
-
         return Response.ok().entity(newsApiResponse).build();
     }
 

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
@@ -96,7 +96,6 @@ public class UserApiImpl extends CommonApi implements UsersApi {
 
     @PreAuthorize(GET_ALL_USER_CONTACT_PERMISSION)
     @Override
-    @SuppressWarnings("unchecked")
     public Response queryContactsOnUser(Long userId,
                                         @Min(1) Integer pageNumber,
                                         @Min(1) @Max(10) Integer pageSize,
@@ -130,7 +129,6 @@ public class UserApiImpl extends CommonApi implements UsersApi {
      */
     @PreAuthorize(GET_ALL_USERS_PERMISSION)
     @Override
-    @SuppressWarnings("unchecked")
     public Response getAllUsers(@Min(1) Integer pageNumber,
                                 @Min(1) @Max(10) Integer pageSize,
                                 String sort,
@@ -149,7 +147,7 @@ public class UserApiImpl extends CommonApi implements UsersApi {
     @PreAuthorize(GET_USER_CONTACT_PERMISSION)
     @Override
     public Response getContactOnUser(Long userId, Long id) {
-        ContactDto readContactDto = contactService.getOne(id);
+        ContactDto readContactDto = contactService.getOne(id, getSpecification());
         ReadContact readContact = mapper.convert(readContactDto, ReadContact.class);
 
         return Response.status(Response.Status.OK).entity(readContact).build();

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
@@ -168,9 +168,9 @@ public class UserApiImpl extends CommonApi implements UsersApi {
 
     @PreAuthorize(UPDATE_USER_CONTACT_PERMISSION)
     @Override
-    public Response updateContactOnUser(Long userId, Long contactId, @Valid UpdateContact updateContact) {
+    public Response updateContactOnUser(Long userId, Long id, @Valid UpdateContact updateContact) {
         var updateContactDto = mapper.convert(updateContact, ContactDto.class);
-        var readContactDto = contactService.updateContact(userId, contactId, updateContactDto);
+        var readContactDto = contactService.updateContact(userId, id, updateContactDto);
         ReadContact readContact = mapper.convert(readContactDto, ReadContact.class);
 
         return Response.status(Response.Status.OK).entity(readContact).build();

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
@@ -95,12 +95,11 @@ public class UserApiImpl extends CommonApi implements UsersApi {
 
     @PreAuthorize(GET_ALL_USER_CONTACT_PERMISSION)
     @Override
-    public Response queryContactsOnUser(Long userId,
-                                        @Min(1) Integer pageNumber,
+    public Response queryContactsOnUser(Long userId, @Min(1) Integer pageNumber,
                                         @Min(1) @Max(10) Integer pageSize,
                                         String sort,
                                         String filter,
-                                        String id,
+                                        Long id,
                                         String phone,
                                         String email,
                                         String main,
@@ -132,7 +131,7 @@ public class UserApiImpl extends CommonApi implements UsersApi {
                                 @Min(1) @Max(10) Integer pageSize,
                                 String sort,
                                 String filter,
-                                String id,
+                                Long id,
                                 String email,
                                 String firstName,
                                 String lastName,

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
@@ -95,7 +95,6 @@ public class UserApiImpl extends CommonApi implements UsersApi {
 
     @PreAuthorize(GET_ALL_USER_CONTACT_PERMISSION)
     @Override
-    @SuppressWarnings("unchecked")
     public Response queryContactsOnUser(Long userId,
                                         @Min(1) Integer pageNumber,
                                         @Min(1) @Max(10) Integer pageSize,

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
@@ -87,7 +87,7 @@ public class UserApiImpl extends CommonApi implements UsersApi {
     @PreAuthorize(GET_USER_BY_ID_PERMISSION)
     @Override
     public Response getUser(Long id) {
-        UserDto readUserDto = (UserDto) queryApiService.getOne(uriInfo, userService);
+        UserDto readUserDto = userService.getOne(id);
         ReadUser readUser = mapper.convert(readUserDto, ReadUser.class);
 
         return Response.status(Response.Status.OK).entity(readUser).build();
@@ -107,7 +107,7 @@ public class UserApiImpl extends CommonApi implements UsersApi {
                                         String main,
                                         String type) {
 
-        Page<ContactDto> contacts = queryApiService.getPageFromQuery(uriInfo, contactService);
+        Page<ContactDto> contacts = contactService.findAll(pageNumber, pageSize, getSpecification());
         return buildQueryResponse(contacts, ReadContact.class);
     }
 
@@ -129,7 +129,6 @@ public class UserApiImpl extends CommonApi implements UsersApi {
      */
     @PreAuthorize(GET_ALL_USERS_PERMISSION)
     @Override
-    @SuppressWarnings("unchecked")
     public Response getAllUsers(@Min(1) Integer pageNumber,
                                 @Min(1) @Max(10) Integer pageSize,
                                 String sort,
@@ -141,14 +140,14 @@ public class UserApiImpl extends CommonApi implements UsersApi {
                                 String contactPhone,
                                 String contactEmail) {
 
-        Page<UserDto> users = queryApiService.getPageFromQuery(uriInfo, userService);
+        Page<UserDto> users = userService.findAll(pageNumber, pageSize, getSpecification());
         return buildQueryResponse(users, ReadUser.class);
     }
 
     @PreAuthorize(GET_USER_CONTACT_PERMISSION)
     @Override
     public Response getContactOnUser(Long userId, Long contactId) {
-        ContactDto readContactDto = (ContactDto) queryApiService.getOne(uriInfo, contactService);
+        ContactDto readContactDto = contactService.getOne(contactId);
         ReadContact readContact = mapper.convert(readContactDto, ReadContact.class);
 
         return Response.status(Response.Status.OK).entity(readContact).build();

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
@@ -111,8 +111,8 @@ public class UserApiImpl extends CommonApi implements UsersApi {
 
     @PreAuthorize(DELETE_USER_CONTACT_PERMISSION)
     @Override
-    public Response deleteContactOnUser(Long userId, Long contactId) {
-        contactService.deactivateContact(contactId);
+    public Response deleteContactOnUser(Long userId, Long id) {
+        contactService.deactivateContact(id);
 
         return Response.status(Response.Status.NO_CONTENT).build();
     }
@@ -144,8 +144,8 @@ public class UserApiImpl extends CommonApi implements UsersApi {
 
     @PreAuthorize(GET_USER_CONTACT_PERMISSION)
     @Override
-    public Response getContactOnUser(Long userId, Long contactId) {
-        ContactDto readContactDto = contactService.getOne(contactId);
+    public Response getContactOnUser(Long userId, Long id) {
+        ContactDto readContactDto = contactService.getOne(id);
         ReadContact readContact = mapper.convert(readContactDto, ReadContact.class);
 
         return Response.status(Response.Status.OK).entity(readContact).build();

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
@@ -84,50 +84,6 @@ public interface QueryApiService<T extends BaseEntity> {
     }
 
     /**
-     * @param uriInfo - object that implements UriInfo interface
-     *                  that provides access to application and request URI information
-     * @param service - implementation of QueryableService interface
-     * @return Spring Data Page of DTOs according to request query
-     * @throws NotFoundHomeException if number of Page elements less than 1
-     */
-    default Page<D> getPageFromQuery(UriInfo uriInfo, QueryableService<T, D> service) {
-        int pageNumber = Integer.parseInt(getParameterValue(DefaultQueryParams.PAGE_NUMBER.getParameter(), uriInfo)
-                .orElse(DefaultQueryParams.PAGE_NUMBER.getValue()));
-        int pageSize = Integer.parseInt(getParameterValue(DefaultQueryParams.PAGE_SIZE.getParameter(), uriInfo)
-                .orElse(DefaultQueryParams.PAGE_SIZE.getValue()));
-        return service.findAll(pageNumber, pageSize, getSpecification(uriInfo));
-    }
-
-    private static String getMessage(UriInfo uriInfo) {
-        String message = "Entity with '%s' is not found";
-        MultivaluedMap<String, String> pathParams = uriInfo.getPathParameters();
-        String ids = pathParams.entrySet().stream()
-            .map(entry -> entry.getKey() + ": " + entry.getValue().get(0))
-            .collect(Collectors.joining(" and "));
-        return String.format(message, ids);
-    }
-
-    /**
-     * @param uriInfo - object that implements UriInfo interface
-     *                  that provides access to application and request URI information
-     * @param service - implementation of QueryableService interface
-     * @return Single DTO
-     * @throws NotFoundHomeException if number of Page elements less than 1
-     * @throws IllegalStateException if number of Page elements more than 1
-     */
-    default D getOne(UriInfo uriInfo, QueryableService<T, D> service) {
-        Page<D> page = getPageFromQuery(uriInfo, service);
-        if (page.getTotalElements() == 1) {
-            return page.getContent().get(0);
-        } else if (page.getTotalElements() == 0) {
-            throw new NotFoundHomeException(getMessage(uriInfo));
-        } else {
-            throw new IllegalStateException("Result of the request that require to return one element, "
-                + "contains more than one element");
-        }
-    }
-
-    /**
      * Enum of default query parameters that have to be excluded from filter map
      */
     enum DefaultQueryParams {

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/QueryApiService.java
@@ -13,21 +13,16 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
 
 import com.softserveinc.ita.homeproject.homedata.entity.BaseEntity;
-import com.softserveinc.ita.homeproject.homeservice.dto.BaseDto;
 import com.softserveinc.ita.homeproject.homeservice.exception.BadRequestHomeException;
-import com.softserveinc.ita.homeproject.homeservice.exception.NotFoundHomeException;
-import com.softserveinc.ita.homeproject.homeservice.service.QueryableService;
-import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.domain.Specification;
 
 /**
  * QueryApiService - service that provides Spring Data Page by request query
  * @author Oleksii Zinkevych
  * @param <T> - entity type
- * @param <D> - DTO type
  * @see javax.ws.rs.core.UriInfo
  */
-public interface QueryApiService<T extends BaseEntity, D extends BaseDto> {
+public interface QueryApiService<T extends BaseEntity> {
     Map<String, String> EXCLUDED_PARAMETERS = Arrays.stream(DefaultQueryParams.values())
             .collect(Collectors.toMap(DefaultQueryParams::getParameter, DefaultQueryParams::getValue));
 

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/impl/EntitySpecificationServiceImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/impl/EntitySpecificationServiceImpl.java
@@ -27,14 +27,12 @@ public class EntitySpecificationServiceImpl<T> implements EntitySpecificationSer
 
     @Override
     public Specification<T> getSpecification(MultivaluedMap<String, String> filter, String search, String sort) {
-
         Specification<T> filterSpecification = RSQLJPASupport.toSpecification(toRSQLString(filter));
         Specification<T> searchSpecification = RSQLJPASupport.toSpecification(search);
         Specification<T> sortSpecification = RSQLJPASupport.toSort(sort);
 
-        return Optional.ofNullable(sortSpecification)
+        return Optional.of(sortSpecification)
                 .map(spec -> spec.and(filterSpecification))
                 .map(spec -> spec.and(searchSpecification)).orElseThrow();
     }
-
 }

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/impl/EntitySpecificationServiceImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/impl/EntitySpecificationServiceImpl.java
@@ -35,7 +35,6 @@ public class EntitySpecificationServiceImpl<T> implements EntitySpecificationSer
         return Optional.ofNullable(sortSpecification)
                 .map(spec -> spec.and(filterSpecification))
                 .map(spec -> spec.and(searchSpecification)).orElseThrow();
-
     }
 
 }

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImpl.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @RequiredArgsConstructor
-public class QueryApiServiceImpl<T extends BaseEntity, D extends BaseDto> implements QueryApiService<T, D> {
+public class QueryApiServiceImpl<T extends BaseEntity> implements QueryApiService<T> {
     private final EntitySpecificationService<T> specificationService;
 
     @Override

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImpl.java
@@ -24,9 +24,10 @@ public class QueryApiServiceImpl<T extends BaseEntity> implements QueryApiServic
     @Override
     public Specification<T> getSpecification(UriInfo uriInfo) {
         String filter = QueryApiService.getParameterValue(DefaultQueryParams.FILTER.getParameter(), uriInfo)
-                .orElse(null);
+            .orElse(null);
         String sort = QueryApiService.getParameterValue(DefaultQueryParams.SORT.getParameter(), uriInfo)
-                .orElse(DefaultQueryParams.SORT.getValue());
-        return specificationService.getSpecification(QueryApiService.getFilterMap(uriInfo), filter, sort);
+            .orElse(DefaultQueryParams.SORT.getValue());
+        return specificationService.getSpecification(QueryApiService.getFilterMap(uriInfo), filter, sort)
+            .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
     }
 }

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImpl.java
@@ -5,7 +5,6 @@ import javax.ws.rs.core.UriInfo;
 import com.softserveinc.ita.homeproject.application.service.EntitySpecificationService;
 import com.softserveinc.ita.homeproject.application.service.QueryApiService;
 import com.softserveinc.ita.homeproject.homedata.entity.BaseEntity;
-import com.softserveinc.ita.homeproject.homeservice.dto.BaseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;

--- a/home-application/src/test/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImplTest.java
+++ b/home-application/src/test/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImplTest.java
@@ -2,48 +2,25 @@ package com.softserveinc.ita.homeproject.application.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
 import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
 
-import com.softserveinc.ita.homeproject.application.service.EntitySpecificationService;
 import com.softserveinc.ita.homeproject.application.service.QueryApiService;
 import com.softserveinc.ita.homeproject.homeservice.exception.BadRequestHomeException;
-import com.softserveinc.ita.homeproject.homeservice.service.QueryableService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
-@SuppressWarnings({"rawtypes", "unchecked"})
 class QueryApiServiceImplTest {
 
     @Mock
-    private static EntitySpecificationService entitySpecificationService;
-
-    @Mock
     private static UriInfo uriInfo;
-
-    @Mock
-    private static QueryableService queryableService;
-
-    @Mock
-    private static Specification specification;
-
-    @InjectMocks
-    private QueryApiServiceImpl queryApiService;
 
     @Test
     void getFilterMapTestWhenQueryOrPathParamsHaveTwoValues() {

--- a/home-application/src/test/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImplTest.java
+++ b/home-application/src/test/java/com/softserveinc/ita/homeproject/application/service/impl/QueryApiServiceImplTest.java
@@ -59,21 +59,4 @@ class QueryApiServiceImplTest {
         assertEquals("1", QueryApiService.getParameterValue("id", uriInfo).orElseThrow());
         assertEquals("4", QueryApiService.getParameterValue("user_id", uriInfo).orElseThrow());
     }
-
-    @Test
-    void getOneTestWhenPageHaveMoreThanOneElement() {
-        when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>() {{
-            put("page_number", Collections.singletonList("1"));
-            put("page_size", Collections.singletonList("10"));
-            put("filter", Collections.singletonList("filter"));
-        }});
-        when(uriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>() {{
-            put("id", Collections.singletonList("1"));
-        }});
-        Page page = new PageImpl(Arrays.asList("1", "2", "3"));
-        when(entitySpecificationService.getSpecification(any(MultivaluedMap.class), anyString(), anyString()))
-            .thenReturn(specification);
-        when(queryableService.findAll(anyInt(), anyInt(), any(Specification.class))).thenReturn(page);
-        assertThrows(IllegalStateException.class, () -> queryApiService.getOne(uriInfo, queryableService));
-    }
 }

--- a/home-open-api/src/main/resources/yaml/openapi.yaml
+++ b/home-open-api/src/main/resources/yaml/openapi.yaml
@@ -312,7 +312,7 @@ paths:
         - contact
       summary: Get Contact by ID
       description: The endpoint retrieves an existing contact
-                   associated with the specified User by User and Contact IDs
+        associated with the specified User by User and Contact IDs
       operationId: getContactOnUser
       parameters:
         - $ref: '#/components/parameters/p_user_id'
@@ -333,7 +333,7 @@ paths:
         - contact
       summary: Update Contact
       description: The endpoint updates information on a contact that exists
-                  in the system by the specified User and Contact IDs
+        in the system by the specified User and Contact IDs
       operationId: updateContactOnUser
       parameters:
         - $ref: '#/components/parameters/p_user_id'
@@ -358,7 +358,7 @@ paths:
         - contact
       summary: Delete Contact
       description: The endpoint deletes an existing Contact on a User associated with the
-                   specified User and Contact IDs
+        specified User and Contact IDs
       operationId: deleteContactOnUser
       parameters:
         - $ref: '#/components/parameters/p_user_id'
@@ -679,7 +679,7 @@ paths:
         - cooperation contact
       summary: Update Contact
       description: The endpoint updates information on a contact that exists
-          in the system by the specified Cooperation and Contact IDs
+        in the system by the specified Cooperation and Contact IDs
       operationId: updateContactOnCooperation
       parameters:
         - $ref: '#/components/parameters/p_cooperation_id'

--- a/home-open-api/src/main/resources/yaml/openapi.yaml
+++ b/home-open-api/src/main/resources/yaml/openapi.yaml
@@ -312,7 +312,7 @@ paths:
         - contact
       summary: Get Contact by ID
       description: The endpoint retrieves an existing contact
-        associated with the specified User by User and Contact IDs
+                   associated with the specified User by User and Contact IDs
       operationId: getContactOnUser
       parameters:
         - $ref: '#/components/parameters/p_user_id'
@@ -333,7 +333,7 @@ paths:
         - contact
       summary: Update Contact
       description: The endpoint updates information on a contact that exists
-        in the system by the specified User and Contact IDs
+                  in the system by the specified User and Contact IDs
       operationId: updateContactOnUser
       parameters:
         - $ref: '#/components/parameters/p_user_id'
@@ -358,7 +358,7 @@ paths:
         - contact
       summary: Delete Contact
       description: The endpoint deletes an existing Contact on a User associated with the
-        specified User and Contact IDs
+                   specified User and Contact IDs
       operationId: deleteContactOnUser
       parameters:
         - $ref: '#/components/parameters/p_user_id'
@@ -679,7 +679,7 @@ paths:
         - cooperation contact
       summary: Update Contact
       description: The endpoint updates information on a contact that exists
-        in the system by the specified Cooperation and Contact IDs
+          in the system by the specified Cooperation and Contact IDs
       operationId: updateContactOnCooperation
       parameters:
         - $ref: '#/components/parameters/p_cooperation_id'

--- a/home-service/pom.xml
+++ b/home-service/pom.xml
@@ -12,12 +12,58 @@
 
     <artifactId>home-service</artifactId>
 
+    <properties>
+        <surefire-version>3.0.0-M5</surefire-version>
+    </properties>
+
     <dependencies>
         <dependency>
             <artifactId>home-data</artifactId>
             <groupId>com.softserveinc.ita.homeproject</groupId>
             <version>${revision}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-version}</version>
+                <configuration>
+                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/CooperationContactService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/CooperationContactService.java
@@ -1,6 +1,4 @@
 package com.softserveinc.ita.homeproject.homeservice.service;
 
-import com.softserveinc.ita.homeproject.homeservice.dto.ContactDto;
-
 public interface CooperationContactService extends ContactService {
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/CooperationContactService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/CooperationContactService.java
@@ -3,6 +3,4 @@ package com.softserveinc.ita.homeproject.homeservice.service;
 import com.softserveinc.ita.homeproject.homeservice.dto.ContactDto;
 
 public interface CooperationContactService extends ContactService {
-
-    ContactDto getContactById(Long id);
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/QueryableService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/QueryableService.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 
 import com.softserveinc.ita.homeproject.homedata.entity.BaseEntity;
 import com.softserveinc.ita.homeproject.homeservice.dto.BaseDto;
+import com.softserveinc.ita.homeproject.homeservice.exception.NotFoundHomeException;
+import org.springframework.core.GenericTypeResolver;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,5 +18,56 @@ import org.springframework.transaction.annotation.Transactional;
  * @param <D> - DTO type
  */
 public interface QueryableService<T extends BaseEntity, D extends BaseDto> {
+    String NOT_FOUND_MESSAGE = "%s with 'id: %s' is not found";
+
+    String MORE_THAN_ONE_ELEMENT_MESSAGE =
+        "Result of the request that require to return one element, contains more than one element";
+
+    int DEFAULT_PAGE_NUMBER = 1;
+
+    int DEFAULT_PAGE_SIZE = 5;
+
+    /**
+     * @param pageNumber - integer value of number og pages
+     * @param pageSize - integer value of elements in page
+     * @param specification - Spring Data Specification
+     * @return - Spring Data Page of DTOs according to Specification
+     */
+    @Transactional
     Page<D> findAll(Integer pageNumber, Integer pageSize, Specification<T> specification);
+
+    /**
+     * @param id - long value of id of the element
+     * @return Single DTO
+     * @throws NotFoundHomeException if number of Page elements less than 1
+     * @throws IllegalStateException if number of Page elements more than 1
+     */
+    @Transactional
+    default D getOne(Long id) {
+        Specification<T> specification =
+            (root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("id"), id);
+        Page<D> page = findAll(DEFAULT_PAGE_NUMBER, DEFAULT_PAGE_SIZE, specification);
+        if (page.getTotalElements() == 1) {
+            return page.getContent().get(0);
+        } else if (page.getTotalElements() == 0) {
+            throw new NotFoundHomeException(getMessage(id));
+        } else {
+            throw new IllegalStateException(MORE_THAN_ONE_ELEMENT_MESSAGE);
+        }
+    }
+
+    private String getMessage(Long id) {
+        String className = getEntityClassName().orElse("Entity");
+        return String.format(NOT_FOUND_MESSAGE, className, id);
+    }
+
+    private Optional<String> getEntityClassName() {
+        Class<?>[] classes = GenericTypeResolver
+            .resolveTypeArguments(getClass(), QueryableService.class);
+        if (classes != null) {
+            return Optional.of((classes[0].getSimpleName()));
+        } else {
+            return Optional.empty();
+        }
+    }
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/QueryableService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/QueryableService.java
@@ -46,6 +46,8 @@ public interface QueryableService<T extends BaseEntity, D extends BaseDto> {
     default D getOne(Long id) {
         Specification<T> specification =
             (root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("id"), id);
+        specification = specification
+            .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
         return getOneDto(id, specification);
     }
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/QueryableService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/QueryableService.java
@@ -1,15 +1,19 @@
 package com.softserveinc.ita.homeproject.homeservice.service;
 
+import java.util.Optional;
+
 import com.softserveinc.ita.homeproject.homedata.entity.BaseEntity;
 import com.softserveinc.ita.homeproject.homeservice.dto.BaseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * QueryableService - service that provides Spring Data Page by entity specification
  * and page parameters
- *
  * @author Oleksii Zinkevych
+ * @param <T> - entity type
+ * @param <D> - DTO type
  */
 public interface QueryableService<T extends BaseEntity, D extends BaseDto> {
     Page<D> findAll(Integer pageNumber, Integer pageSize, Specification<T> specification);

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/QueryableService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/QueryableService.java
@@ -46,6 +46,22 @@ public interface QueryableService<T extends BaseEntity, D extends BaseDto> {
     default D getOne(Long id) {
         Specification<T> specification =
             (root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("id"), id);
+        return getOneDto(id, specification);
+    }
+
+    /**
+     * @param id - long value of id of the element
+     * @param specification - Spring Data Specification
+     * @return Single DTO
+     * @throws NotFoundHomeException if number of Page elements less than 1
+     * @throws IllegalStateException if number of Page elements more than 1
+     */
+    @Transactional
+    default D getOne(Long id, Specification<T> specification) {
+        return getOneDto(id, specification);
+    }
+
+    private D getOneDto(Long id, Specification<T> specification) {
         Page<D> page = findAll(DEFAULT_PAGE_NUMBER, DEFAULT_PAGE_SIZE, specification);
         if (page.getTotalElements() == 1) {
             return page.getContent().get(0);

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ApartmentServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ApartmentServiceImpl.java
@@ -81,9 +81,10 @@ public class ApartmentServiceImpl implements ApartmentService {
     @Override
     @Transactional
     public Page<ApartmentDto> findAll(Integer pageNumber, Integer pageSize, Specification<Apartment> specification) {
-        Specification<Apartment> apartmentSpecification = specification
-                .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        return apartmentRepository.findAll(apartmentSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        specification = specification
+            .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder
+                .equal(root.get("house").get("enabled"), true));
+        return apartmentRepository.findAll(specification, PageRequest.of(pageNumber - 1, pageSize))
                 .map(apartment -> mapper.convert(apartment, ApartmentDto.class));
     }
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/BaseContactService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/BaseContactService.java
@@ -87,13 +87,6 @@ public abstract class BaseContactService implements ContactService {
             .map(contact -> mapper.convert(contact, ContactDto.class));
     }
 
-
-    public ContactDto getContactById(Long id) {
-        var contactResponse = contactRepository.findById(id).filter(Contact::getEnabled)
-            .orElseThrow(() -> new NotFoundHomeException("Can't find contact with given ID:" + id));
-        return mapper.convert(contactResponse, ContactDto.class);
-    }
-
     @Override
     public void deactivateContact(Long id) {
         var contact = contactRepository.findById(id).filter(Contact::getEnabled)

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/BaseContactService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/BaseContactService.java
@@ -81,11 +81,12 @@ public abstract class BaseContactService implements ContactService {
 
     protected abstract Contact checkAndGetContactByParentId(Long id, Long parentEntityId);
 
+    protected abstract <T extends Contact> Specification<T> updateSpecification(Specification<T> specification);
+
     @Override
     public Page<ContactDto> findAll(Integer pageNumber, Integer pageSize, Specification<Contact> specification) {
-        Specification<Contact> contactSpecification = specification
-            .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        return contactRepository.findAll(contactSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        specification = updateSpecification(specification);
+        return contactRepository.findAll(specification, PageRequest.of(pageNumber - 1, pageSize))
             .map(contact -> mapper.convert(contact, ContactDto.class));
     }
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationContactServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationContactServiceImpl.java
@@ -12,29 +12,27 @@ import com.softserveinc.ita.homeproject.homeservice.exception.AlreadyExistHomeEx
 import com.softserveinc.ita.homeproject.homeservice.exception.NotFoundHomeException;
 import com.softserveinc.ita.homeproject.homeservice.mapper.ServiceMapper;
 import com.softserveinc.ita.homeproject.homeservice.service.CooperationContactService;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 
 @Service
 public class CooperationContactServiceImpl extends BaseContactService implements CooperationContactService {
 
-    private final CooperationRepository cooperationRepository;
+    private static final String NOT_FOUND_MESSAGE = "Cooperation with 'id: %s' is not found";
 
-    private final CooperationServiceImpl cooperationService;
+    private final CooperationRepository cooperationRepository;
 
     public CooperationContactServiceImpl(ContactRepository contactRepository,
                                          ServiceMapper mapper,
-                                         CooperationRepository cooperationRepository,
-                                         CooperationServiceImpl cooperationService) {
+                                         CooperationRepository cooperationRepository) {
         super(contactRepository, mapper);
-        this.cooperationService = cooperationService;
         this.cooperationRepository = cooperationRepository;
     }
 
     @Override
     protected void checkAndFillParentEntity(ContactDto contactDto, Contact createContact, Long parentEntityId) {
-        var cooperation = mapper
-            .convert(cooperationService.getOne(parentEntityId), Cooperation.class);
+        var cooperation = getCooperationById(parentEntityId);
         if (Boolean.TRUE.equals(contactDto.getMain())) {
             List<Contact> getAllContactByCoopId = contactRepository
                 .findAllByCooperationIdAndType(parentEntityId, mapper.convert(contactDto.getType(), ContactType.class));
@@ -53,10 +51,20 @@ public class CooperationContactServiceImpl extends BaseContactService implements
 
     @Override
     protected Contact checkAndGetContactByParentId(Long id, Long parentEntityId) {
-        var cooperation = cooperationRepository.findById(parentEntityId).filter(Cooperation::getEnabled)
-            .orElseThrow(() -> new NotFoundHomeException("Cooperation with id:" + parentEntityId + " is not found"));
+        var cooperation = getCooperationById(parentEntityId);
         return cooperation.getContacts().stream()
             .filter(Contact::getEnabled).filter(contact -> contact.getId().equals(id)).findFirst()
             .orElseThrow(() -> new NotFoundHomeException("Contact with id:" + id + " is not found"));
+    }
+
+    @Override
+    protected <T extends Contact> Specification<T> updateSpecification(Specification<T> specification) {
+        return specification.and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder
+            .equal(root.get("cooperation").get("enabled"), true));
+    }
+
+    private Cooperation getCooperationById(Long id) {
+        return cooperationRepository.findById(id).filter(Cooperation::getEnabled)
+            .orElseThrow(() -> new NotFoundHomeException(String.format(NOT_FOUND_MESSAGE, id)));
     }
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationContactServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationContactServiceImpl.java
@@ -34,7 +34,7 @@ public class CooperationContactServiceImpl extends BaseContactService implements
     @Override
     protected void checkAndFillParentEntity(ContactDto contactDto, Contact createContact, Long parentEntityId) {
         var cooperation = mapper
-            .convert(cooperationService.getCooperationById(parentEntityId), Cooperation.class);
+            .convert(cooperationService.getOne(parentEntityId), Cooperation.class);
         if (Boolean.TRUE.equals(contactDto.getMain())) {
             List<Contact> getAllContactByCoopId = contactRepository
                 .findAllByCooperationIdAndType(parentEntityId, mapper.convert(contactDto.getType(), ContactType.class));

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
@@ -26,10 +26,6 @@ public class CooperationServiceImpl implements CooperationService {
 
     private final ServiceMapper mapper;
 
-    private final HouseRepository houseRepository;
-
-    private final ContactRepository contactRepository;
-
     @Transactional
     @Override
     public CooperationDto createCooperation(CooperationDto createCooperationDto) {
@@ -80,16 +76,6 @@ public class CooperationServiceImpl implements CooperationService {
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
         return cooperationRepository.findAll(cooperationSpecification, PageRequest.of(pageNumber - 1, pageSize))
             .map(cooperation -> mapper.convert(cooperation, CooperationDto.class));
-    }
-
-    public CooperationDto getCooperationById(Long id) {
-        Cooperation toGet = cooperationRepository.findById(id).filter(Cooperation::getEnabled)
-            .orElseThrow(() -> new NotFoundHomeException(String.format(NOT_FOUND_COOPERATION_FORMAT, id)));
-        List<House> houseList = houseRepository.findHousesByCooperationId(toGet.getId());
-        toGet.setHouses(houseList);
-        List<Contact> contactList = new ArrayList<>(contactRepository.findAllByCooperationId(toGet.getId()));
-        toGet.setContacts(contactList);
-        return mapper.convert(toGet, CooperationDto.class);
     }
 
     @Override

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
@@ -72,9 +72,7 @@ public class CooperationServiceImpl implements CooperationService {
     @Override
     public Page<CooperationDto> findAll(Integer pageNumber, Integer pageSize,
                                         Specification<Cooperation> specification) {
-        Specification<Cooperation> cooperationSpecification = specification
-            .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        return cooperationRepository.findAll(cooperationSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        return cooperationRepository.findAll(specification, PageRequest.of(pageNumber - 1, pageSize))
             .map(cooperation -> mapper.convert(cooperation, CooperationDto.class));
     }
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationServiceImpl.java
@@ -2,15 +2,9 @@ package com.softserveinc.ita.homeproject.homeservice.service.impl;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
-import com.softserveinc.ita.homeproject.homedata.entity.Contact;
 import com.softserveinc.ita.homeproject.homedata.entity.Cooperation;
-import com.softserveinc.ita.homeproject.homedata.entity.House;
-import com.softserveinc.ita.homeproject.homedata.repository.ContactRepository;
 import com.softserveinc.ita.homeproject.homedata.repository.CooperationRepository;
-import com.softserveinc.ita.homeproject.homedata.repository.HouseRepository;
 import com.softserveinc.ita.homeproject.homeservice.dto.CooperationDto;
 import com.softserveinc.ita.homeproject.homeservice.exception.NotFoundHomeException;
 import com.softserveinc.ita.homeproject.homeservice.mapper.ServiceMapper;
@@ -79,7 +73,6 @@ public class CooperationServiceImpl implements CooperationService {
         return mapper.convert(fromDb, CooperationDto.class);
     }
 
-    @Transactional
     @Override
     public Page<CooperationDto> findAll(Integer pageNumber, Integer pageSize,
                                         Specification<Cooperation> specification) {

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/HouseServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/HouseServiceImpl.java
@@ -68,7 +68,6 @@ public class HouseServiceImpl implements HouseService {
         return mapper.convert(fromDb, HouseDto.class);
     }
 
-    @Transactional
     @Override
     public Page<HouseDto> findAll(Integer pageNumber, Integer pageSize, Specification<House> specification) {
         Specification<House> houseSpecification = specification

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/HouseServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/HouseServiceImpl.java
@@ -70,9 +70,7 @@ public class HouseServiceImpl implements HouseService {
 
     @Override
     public Page<HouseDto> findAll(Integer pageNumber, Integer pageSize, Specification<House> specification) {
-        Specification<House> houseSpecification = specification
-            .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        return houseRepository.findAll(houseSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        return houseRepository.findAll(specification, PageRequest.of(pageNumber - 1, pageSize))
             .map(house -> mapper.convert(house, HouseDto.class));
     }
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/NewsServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/NewsServiceImpl.java
@@ -73,9 +73,7 @@ public class NewsServiceImpl implements NewsService {
 
     @Override
     public Page<NewsDto> findAll(Integer pageNumber, Integer pageSize, Specification<News> specification) {
-        Specification<News> newsSpecification = specification
-            .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        return newsRepository.findAll(newsSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        return newsRepository.findAll(specification, PageRequest.of(pageNumber - 1, pageSize))
             .map(news -> mapper.convert(news, NewsDto.class));
     }
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserContactServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserContactServiceImpl.java
@@ -32,7 +32,7 @@ public class UserContactServiceImpl extends BaseContactService implements UserCo
 
     @Override
     protected void checkAndFillParentEntity(ContactDto contactDto, Contact createContact, Long parentEntityId) {
-        var user = mapper.convert(userService.getUserById(parentEntityId), User.class);
+        var user = mapper.convert(getOne(parentEntityId), User.class);
         if (Boolean.TRUE.equals(contactDto.getMain())) {
             List<Contact> allByUserIdAndType = contactRepository
                 .findAllByUserIdAndType(parentEntityId, mapper.convert(contactDto.getType(), ContactType.class));

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserContactServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserContactServiceImpl.java
@@ -17,16 +17,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class UserContactServiceImpl extends BaseContactService implements UserContactService {
 
-    private final UserServiceImpl userService;
-
     private final UserRepository userRepository;
 
     public UserContactServiceImpl(ContactRepository contactRepository,
                                   ServiceMapper mapper,
-                                  UserServiceImpl userService,
                                   UserRepository userRepository) {
         super(contactRepository, mapper);
-        this.userService = userService;
         this.userRepository = userRepository;
     }
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserContactServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserContactServiceImpl.java
@@ -12,10 +12,13 @@ import com.softserveinc.ita.homeproject.homeservice.exception.AlreadyExistHomeEx
 import com.softserveinc.ita.homeproject.homeservice.exception.NotFoundHomeException;
 import com.softserveinc.ita.homeproject.homeservice.mapper.ServiceMapper;
 import com.softserveinc.ita.homeproject.homeservice.service.UserContactService;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 @Service
 public class UserContactServiceImpl extends BaseContactService implements UserContactService {
+
+    private static final String NOT_FOUND_MESSAGE = "User with 'id: %s' is not found";
 
     private final UserRepository userRepository;
 
@@ -28,7 +31,7 @@ public class UserContactServiceImpl extends BaseContactService implements UserCo
 
     @Override
     protected void checkAndFillParentEntity(ContactDto contactDto, Contact createContact, Long parentEntityId) {
-        var user = mapper.convert(getOne(parentEntityId), User.class);
+        var user = getUserById(parentEntityId);
         if (Boolean.TRUE.equals(contactDto.getMain())) {
             List<Contact> allByUserIdAndType = contactRepository
                 .findAllByUserIdAndType(parentEntityId, mapper.convert(contactDto.getType(), ContactType.class));
@@ -46,10 +49,20 @@ public class UserContactServiceImpl extends BaseContactService implements UserCo
 
     @Override
     protected Contact checkAndGetContactByParentId(Long id, Long parentEntityId) {
-        var user = userRepository.findById(parentEntityId).filter(User::getEnabled)
-            .orElseThrow(() -> new NotFoundHomeException("User with id:" + parentEntityId + " is not found"));
+        var user = getUserById(parentEntityId);
         return user.getContacts().stream()
             .filter(Contact::getEnabled).filter(contact -> contact.getId().equals(id)).findFirst()
             .orElseThrow(() -> new NotFoundHomeException("Contact with id:" + id + " is not found"));
+    }
+
+    @Override
+    protected <T extends Contact> Specification<T> updateSpecification(Specification<T> specification) {
+        return specification.and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder
+            .equal(root.get("user").get("enabled"), true));
+    }
+
+    private User getUserById(Long id) {
+        return userRepository.findById(id).filter(User::getEnabled)
+            .orElseThrow(() -> new NotFoundHomeException(String.format(NOT_FOUND_MESSAGE, id)));
     }
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserServiceImpl.java
@@ -99,9 +99,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public Page<UserDto> findAll(Integer pageNumber, Integer pageSize, Specification<User> specification) {
-        Specification<User> userSpecification = specification
-            .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));
-        return userRepository.findAll(userSpecification, PageRequest.of(pageNumber - 1, pageSize))
+        return userRepository.findAll(specification, PageRequest.of(pageNumber - 1, pageSize))
             .map(user -> mapper.convert(user, UserDto.class));
     }
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/impl/UserServiceImpl.java
@@ -95,15 +95,7 @@ public class UserServiceImpl implements UserService {
             });
     }
 
-    @Transactional
-    public UserDto getUserById(Long id) {
-        User toGet = userRepository.findById(id).filter(User::getEnabled)
-            .orElseThrow(() -> new NotFoundHomeException(String.format(USER_NOT_FOUND_FORMAT, id)));
-        return mapper.convert(toGet, UserDto.class);
-    }
-
     @Override
-    @Transactional
     public Page<UserDto> findAll(Integer pageNumber, Integer pageSize, Specification<User> specification) {
         Specification<User> userSpecification = specification
             .and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get("enabled"), true));

--- a/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/NewsServiceImplTest.java
+++ b/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/NewsServiceImplTest.java
@@ -1,0 +1,47 @@
+package com.softserveinc.ita.homeproject.homeservice.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import com.softserveinc.ita.homeproject.homedata.entity.News;
+import com.softserveinc.ita.homeproject.homedata.repository.NewsRepository;
+import com.softserveinc.ita.homeproject.homeservice.dto.NewsDto;
+import com.softserveinc.ita.homeproject.homeservice.mapper.ServiceMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class NewsServiceImplTest {
+
+    @Mock
+    private static ServiceMapper serviceMapper;
+
+    @Mock
+    private static NewsRepository newsRepository;
+
+    @InjectMocks
+    private NewsServiceImpl newsService;
+
+    @BeforeEach
+    void setMocksBehavior() {
+        when(serviceMapper.convert(any(), any())).thenReturn(new NewsDto());
+    }
+
+    @Test
+    void getOneTestWhenPageHaveMoreThanOneElement() {
+        Page<News> page = new PageImpl<>(Arrays.asList(new News(), new News()));
+        when(newsRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(page);
+        assertThrows(IllegalStateException.class, () -> newsService.getOne(1L));
+    }
+}


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/213)
* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/218)

## Code reviewers

- [ ] @kh0ma, @VadymSokorenko, @denis-litvinov, @likeRewca, @Abhai2016, @Ilya-Ross, @annaprok, @BenAvleck

### Second Level Review

- [ ] @github_username

## Summary of issue

QueryApiService implemetation violates Single responsibility principle of SOLID, has not clear way for passing entity services into QueryApiService
Lack of reusability of code in case of using getOne and findAll methods

## Summary of change

getOne and findAll methods moved to QueriableService (service domain)
getOne methid reuses findAll inside

## Testing approach

Automation

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions