### PR TITLE
Home#311 revisit docker image creation on the build

### DIFF
--- a/home-api-tests/pom.xml
+++ b/home-api-tests/pom.xml
@@ -17,8 +17,8 @@
         <surefire-version>3.0.0-M5</surefire-version>
         <commons-lang3-version>3.11</commons-lang3-version>
         <fabric8io.docker.maven.plugin.version>0.24.0</fabric8io.docker.maven.plugin.version>
-        <docker.image.data.migration>home-data-migration:${revision}</docker.image.data.migration>
-        <docker.image.application>home-application:${revision}</docker.image.application>
+        <docker.image.data.migration>homeacademy/data-migration:${revision}</docker.image.data.migration>
+        <docker.image.application>homeacademy/home-application:${revision}</docker.image.application>
         <docker.image.postgres>postgres</docker.image.postgres>
         <docker.image.mailhog>mailhog/mailhog</docker.image.mailhog>
         <docker.image.psql>governmentpaas/psql</docker.image.psql>

--- a/home-api-tests/pom.xml
+++ b/home-api-tests/pom.xml
@@ -17,8 +17,8 @@
         <surefire-version>3.0.0-M5</surefire-version>
         <commons-lang3-version>3.11</commons-lang3-version>
         <fabric8io.docker.maven.plugin.version>0.24.0</fabric8io.docker.maven.plugin.version>
-        <docker.image.data.migration>homeacademy/data-migration:${revision}</docker.image.data.migration>
-        <docker.image.application>homeacademy/home-application:${revision}</docker.image.application>
+        <docker.image.data.migration>homeacademy/data-migration:${docker.revision}</docker.image.data.migration>
+        <docker.image.application>homeacademy/home-application:${docker.revision}</docker.image.application>
         <docker.image.postgres>postgres</docker.image.postgres>
         <docker.image.mailhog>mailhog/mailhog</docker.image.mailhog>
         <docker.image.psql>governmentpaas/psql</docker.image.psql>

--- a/home-application/pom.xml
+++ b/home-application/pom.xml
@@ -182,6 +182,7 @@
                     </to>
                     <container>
                         <mainClass>com.softserveinc.ita.homeproject.HomeApplication</mainClass>
+                        <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                     </container>
                     <allowInsecureRegistries>true</allowInsecureRegistries>
                 </configuration>

--- a/home-application/pom.xml
+++ b/home-application/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <surefire-version>3.0.0-M5</surefire-version>
         <json.name>openapi.json</json.name>
+        <image.application.path>homeacademy/home-application</image.application.path>
     </properties>
 
     <dependencies>

--- a/home-data-migration/pom.xml
+++ b/home-data-migration/pom.xml
@@ -17,6 +17,7 @@
         <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
         <picocli.version>4.6.1</picocli.version>
         <checkstyle.configLocation>src/main/resources/checkstyle-configuration.xml</checkstyle.configLocation>
+        <image.liquibase.path>homeacademy/data-migration</image.liquibase.path>
     </properties>
 
     <profiles>

--- a/home-data-migration/pom.xml
+++ b/home-data-migration/pom.xml
@@ -128,6 +128,7 @@
                     </to>
                     <container>
                         <mainClass>com.softserveinc.ita.homeproject.homedatamigration.migrations.LiquibaseRunner</mainClass>
+                        <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                     </container>
                     <allowInsecureRegistries>true</allowInsecureRegistries>
                 </configuration>

--- a/home-dev/launch/docker-compose.yml
+++ b/home-dev/launch/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    image: home-data-migration:0.0.1-SNAPSHOT
+    image: homeacademy/data-migration
     environment:
       DATASOURCE_URL: jdbc:postgresql://postgres:5432/postgres?user=postgres&password=password
     ports:
@@ -29,7 +29,7 @@ services:
       - home_network
 
   home-application:
-    image: home-application:0.0.1-SNAPSHOT
+    image: homeacademy/home-application
     depends_on:
       home-data-migration:
         condition: service_completed_successfully

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,8 @@
 
     <properties>
         <java.version>11</java.version>
-        <revision>latest</revision>
+        <revision>0.0.1-SNAPSHOT</revision>
+        <docker.revision>latest</docker.revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.boot.version>2.3.8.RELEASE</spring.boot.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <properties>
         <java.version>11</java.version>
-        <revision>0.0.1-SNAPSHOT</revision>
+        <revision>latest</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.boot.version>2.3.8.RELEASE</spring.boot.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009)


## Code reviewers

- [ ] @bbogdasha 
- [ ] @klaeck 
- [ ] @kizimov 
- [ ] @kh0ma 
- [ ] @DzigMS 

## Summary of issue

Make it possible to download the image of home-data-migration and home-application from the docker hub if these images were not created on the local machine. 

## Summary of change

ToDo

## Testing approach

None

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
