### PR TITLE
Issue#335 invitation redesign

### DIFF
--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartment_invitations/ApartmentInvitationApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartment_invitations/ApartmentInvitationApiIT.java
@@ -1,0 +1,66 @@
+package com.softserveinc.ita.homeproject.api.tests.apartment_invitations;
+
+import com.softserveinc.ita.homeproject.api.tests.utils.ApiClientUtil;
+import com.softserveinc.ita.homeproject.client.ApiException;
+import com.softserveinc.ita.homeproject.client.api.ApartmentApi;
+import com.softserveinc.ita.homeproject.client.api.ApartmentInvitationApi;
+import com.softserveinc.ita.homeproject.client.api.CooperationApi;
+import com.softserveinc.ita.homeproject.client.api.HouseApi;
+import com.softserveinc.ita.homeproject.client.model.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.AbstractMap;
+import java.util.Map.Entry;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.concurrent.TimeUnit;
+
+import static com.softserveinc.ita.homeproject.api.tests.utils.mail.mock.InvitationApprovalUtil.approveInvitation;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class ApartmentInvitationApiIT {
+
+    private final ApartmentInvitationApi apartmentInvitationApi = new ApartmentInvitationApi(ApiClientUtil.getCooperationAdminClient());
+
+    private final ApartmentApi apartmentApi = new ApartmentApi();
+
+    private final HouseApi houseApi = new HouseApi();
+
+    private final CooperationApi cooperationApi = new CooperationApi();
+
+    private final int waitTime = 1000;
+
+    @Test
+    void deactivateAcceptedApartmentInvitationTest() throws ApiException, IOException, InterruptedException {
+        Entry<ReadApartmentInvitation, ReadApartment> result = createApartmentInvitation();
+        TimeUnit.MILLISECONDS.sleep(waitTime);
+        approveInvitation(result.getKey().getEmail());
+        assertThatExceptionOfType(HttpClientErrorException.BadRequest.class)
+                .isThrownBy(() -> apartmentInvitationApi.deleteInvitation(result.getValue().getId(), result.getKey().getId()));
+    }
+
+    private Entry<ReadApartmentInvitation, ReadApartment> createApartmentInvitation() throws ApiException {
+        CreateApartmentInvitation createApartmentInvitation = new CreateApartmentInvitation();
+        createApartmentInvitation.setOwnershipPart(BigDecimal.valueOf(0.3));
+        createApartmentInvitation.email("test.receive.messages@gmail.com");
+        createApartmentInvitation.setType(InvitationType.APARTMENT);
+        ReadApartment apartment = createApartment();
+        ReadApartmentInvitation apartmentInvitation = apartmentInvitationApi.createInvitation(apartment.getId(), createApartmentInvitation);
+        return new AbstractMap.SimpleEntry<>(apartmentInvitation, apartment);
+    }
+
+    private ReadApartment createApartment() throws ApiException {
+        ReadHouse house = createHouse();
+        return apartmentApi.createApartment(house.getId(), new CreateApartment());
+    }
+
+    private ReadHouse createHouse() throws ApiException {
+        ReadCooperation cooperation = createCooperation();
+        return houseApi.createHouse(cooperation.getId(), new CreateHouse());
+    }
+
+    private ReadCooperation createCooperation() throws ApiException {
+        return cooperationApi.createCooperation(new CreateCooperation());
+    }
+}

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartment_invitations/ApartmentInvitationApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartment_invitations/ApartmentInvitationApiIT.java
@@ -29,7 +29,7 @@ public class ApartmentInvitationApiIT {
 
     private final CooperationApi cooperationApi = new CooperationApi();
 
-    private final int waitTime = 1000;
+    private final int waitTime = 5000;
 
     @Test
     void deactivateAcceptedApartmentInvitationTest() throws ApiException, IOException, InterruptedException {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartment_invitations/ApartmentInvitationApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartment_invitations/ApartmentInvitationApiIT.java
@@ -7,6 +7,7 @@ import com.softserveinc.ita.homeproject.client.api.ApartmentInvitationApi;
 import com.softserveinc.ita.homeproject.client.api.CooperationApi;
 import com.softserveinc.ita.homeproject.client.api.HouseApi;
 import com.softserveinc.ita.homeproject.client.model.*;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.client.HttpClientErrorException;
 
@@ -16,6 +17,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.concurrent.TimeUnit;
 
+import static com.softserveinc.ita.homeproject.api.tests.utils.CreateSampleUtil.createAddress;
 import static com.softserveinc.ita.homeproject.api.tests.utils.mail.mock.InvitationApprovalUtil.approveInvitation;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -23,11 +25,11 @@ public class ApartmentInvitationApiIT {
 
     private final ApartmentInvitationApi apartmentInvitationApi = new ApartmentInvitationApi(ApiClientUtil.getCooperationAdminClient());
 
-    private final ApartmentApi apartmentApi = new ApartmentApi();
+    private final ApartmentApi apartmentApi = new ApartmentApi(ApiClientUtil.getCooperationAdminClient());
 
-    private final HouseApi houseApi = new HouseApi();
+    private final HouseApi houseApi = new HouseApi(ApiClientUtil.getCooperationAdminClient());
 
-    private final CooperationApi cooperationApi = new CooperationApi();
+    private final CooperationApi cooperationApi = new CooperationApi(ApiClientUtil.getCooperationAdminClient());
 
     private final int waitTime = 5000;
 
@@ -52,15 +54,29 @@ public class ApartmentInvitationApiIT {
 
     private ReadApartment createApartment() throws ApiException {
         ReadHouse house = createHouse();
-        return apartmentApi.createApartment(house.getId(), new CreateApartment());
+        CreateApartment apartment = new CreateApartment()
+                .area(BigDecimal.valueOf(72.5))
+                .number("15");
+        return apartmentApi.createApartment(house.getId(), apartment);
     }
 
     private ReadHouse createHouse() throws ApiException {
         ReadCooperation cooperation = createCooperation();
-        return houseApi.createHouse(cooperation.getId(), new CreateHouse());
+        CreateHouse house = new CreateHouse()
+                .adjoiningArea(500)
+                .houseArea(BigDecimal.valueOf(500.0))
+                .quantityFlat(50)
+                .address(createAddress());
+        return houseApi.createHouse(cooperation.getId(), house);
     }
 
     private ReadCooperation createCooperation() throws ApiException {
-        return cooperationApi.createCooperation(new CreateCooperation());
+        CreateCooperation cooperation = new CreateCooperation()
+                .name(RandomStringUtils.randomAlphabetic(10).concat(" Cooperation"))
+                .usreo(RandomStringUtils.randomNumeric(8))
+                .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
+                .adminEmail(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"))
+                .address(createAddress());
+        return cooperationApi.createCooperation(cooperation);
     }
 }

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/InvitationApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/InvitationApiIT.java
@@ -1,5 +1,6 @@
 package com.softserveinc.ita.homeproject.api.tests.invitations;
 
+import static com.softserveinc.ita.homeproject.api.tests.utils.CreateSampleUtil.createAddress;
 import static com.softserveinc.ita.homeproject.api.tests.utils.mail.mock.InvitationApprovalUtil.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -138,16 +139,6 @@ class InvitationApiIT {
                 .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
                 .adminEmail(createBaseUser().getEmail())
                 .address(createAddress());
-    }
-
-    private Address createAddress() {
-        return new Address().city("Dnepr")
-                .district("District")
-                .houseBlock("block")
-                .houseNumber("number")
-                .region("Dnipro")
-                .street("street")
-                .zipCode("zipCode");
     }
 
     private CreateHouse createHouse() {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/InvitationApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/InvitationApiIT.java
@@ -30,7 +30,6 @@ import com.softserveinc.ita.homeproject.client.model.CreateHouse;
 import com.softserveinc.ita.homeproject.client.model.CreateInvitation;
 import com.softserveinc.ita.homeproject.client.model.CreateUser;
 import com.softserveinc.ita.homeproject.client.model.InvitationStatus;
-import com.softserveinc.ita.homeproject.client.model.InvitationToken;
 import com.softserveinc.ita.homeproject.client.model.InvitationType;
 import com.softserveinc.ita.homeproject.client.model.ReadCooperation;
 import com.softserveinc.ita.homeproject.client.model.ReadHouse;
@@ -49,9 +48,7 @@ class InvitationApiIT {
 
     private final ApartmentApi apartmentApi = new ApartmentApi(ApiClientUtil.getCooperationAdminClient());
 
-    private final InvitationsApi invitationApi = new InvitationsApi(ApiClientUtil.getCooperationAdminClient());
-
-    private final int waitTime = 1000;
+    private final int waitTime = 5000;
 
     @Test
     void isEmailSentTest() throws Exception {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/security/PermissionsIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/security/PermissionsIT.java
@@ -28,7 +28,6 @@ import com.softserveinc.ita.homeproject.client.model.PollType;
 import com.softserveinc.ita.homeproject.client.model.QuestionType;
 import com.softserveinc.ita.homeproject.client.model.ReadCooperation;
 import com.softserveinc.ita.homeproject.client.model.UpdateApartment;
-import com.softserveinc.ita.homeproject.client.model.UpdateApartmentInvitation;
 import com.softserveinc.ita.homeproject.client.model.UpdateContact;
 import com.softserveinc.ita.homeproject.client.model.UpdateCooperation;
 import com.softserveinc.ita.homeproject.client.model.UpdateEmailContact;
@@ -377,8 +376,6 @@ class PermissionsIT {
                 return createBaseCooperation();
             case "com.softserveinc.ita.homeproject.client.model.CreateApartmentInvitation":
                 return createApartmentInvitation();
-            case "com.softserveinc.ita.homeproject.client.model.UpdateApartmentInvitation":
-                return updateApartmentInvitation();
             case "com.softserveinc.ita.homeproject.client.model.InvitationToken":
                 return getInvitationToken();
             default:
@@ -623,12 +620,6 @@ class PermissionsIT {
             .ownershipPart(BigDecimal.valueOf(0.1))
             .email("test.receive.messages@gmail.com")
             .type(InvitationType.APARTMENT);
-    }
-
-    private static UpdateApartmentInvitation updateApartmentInvitation() {
-        return new UpdateApartmentInvitation()
-            .ownershipPart(BigDecimal.valueOf(1))
-            .email("test.receive.messages@gmail.com");
     }
 
     private static CreateApartment createApartment() {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/CreateSampleUtil.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/CreateSampleUtil.java
@@ -1,0 +1,15 @@
+package com.softserveinc.ita.homeproject.api.tests.utils;
+
+import com.softserveinc.ita.homeproject.client.model.Address;
+
+public class CreateSampleUtil {
+    public static Address createAddress() {
+        return new Address().city("Dnepr")
+                .district("District")
+                .houseBlock("block")
+                .houseNumber("number")
+                .region("Dnipro")
+                .street("street")
+                .zipCode("zipCode");
+    }
+}

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/mail/mock/InvitationApprovalUtil.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/mail/mock/InvitationApprovalUtil.java
@@ -1,0 +1,53 @@
+package com.softserveinc.ita.homeproject.api.tests.utils.mail.mock;
+
+import com.softserveinc.ita.homeproject.api.tests.utils.ApiClientUtil;
+import com.softserveinc.ita.homeproject.api.tests.utils.mail.mock.dto.MailHogApiResponse;
+import com.softserveinc.ita.homeproject.client.ApiException;
+import com.softserveinc.ita.homeproject.client.api.InvitationsApi;
+import com.softserveinc.ita.homeproject.client.model.InvitationToken;
+import com.softserveinc.ita.homeproject.client.model.ReadInvitation;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class InvitationApprovalUtil {
+    private static InvitationsApi invitationApi = new InvitationsApi(ApiClientUtil.getCooperationAdminClient());
+
+    public static String getToken(String str) {
+        Pattern pattern = Pattern.compile("(?<=:) .* (?=<)");
+        Matcher matcher = pattern.matcher(str);
+
+        String result = "";
+        if (matcher.find()) {
+            result = matcher.group();
+        }
+        return result.trim();
+    }
+
+    public static ReadInvitation approveInvitation(String userEmail) throws IOException, InterruptedException, ApiException {
+        ApiUsageFacade api = new ApiUsageFacade();
+        MailHogApiResponse mailResponse = api.getMessages(new ApiMailHogUtil(), MailHogApiResponse.class);
+        String cooperationInvitationToken = getToken(getDecodedMessageByEmail(mailResponse, userEmail));
+        return invitationApi.approveInvitation(buildInvitationPayload(cooperationInvitationToken));
+    }
+
+    public static String getDecodedMessageByEmail(MailHogApiResponse response, String email) {
+        String message="";
+        for (int i = 0; i < response.getItems().size(); i++){
+            if(response.getItems().get(i).getContent().getHeaders().getTo().contains(email)){
+                message = response.getItems().get(i).getMime().getParts().get(0).getMime().getParts().get(0).getBody();
+                break;
+            }
+        }
+        return new String(Base64.getMimeDecoder().decode(message), StandardCharsets.UTF_8);
+    }
+
+    public static InvitationToken buildInvitationPayload(String invitationToken){
+        InvitationToken token = new InvitationToken();
+        token.setInvitationToken(invitationToken);
+        return token;
+    }
+}

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/ApartmentApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/ApartmentApiImpl.java
@@ -18,7 +18,6 @@ import com.softserveinc.ita.homeproject.model.CreateApartmentInvitation;
 import com.softserveinc.ita.homeproject.model.InvitationType;
 import com.softserveinc.ita.homeproject.model.ReadApartmentInvitation;
 import com.softserveinc.ita.homeproject.model.ReadOwnership;
-import com.softserveinc.ita.homeproject.model.UpdateApartmentInvitation;
 import com.softserveinc.ita.homeproject.model.UpdateOwnership;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -111,18 +110,6 @@ public class ApartmentApiImpl extends CommonApi implements ApartmentsApi {
         verifyExistence(apartmentId, apartmentService);
         Page<OwnershipDto> readOwnership = ownershipService.findAll(pageNumber, pageSize, getSpecification());
         return buildQueryResponse(readOwnership, ReadOwnership.class);
-    }
-
-    @PreAuthorize(MANAGE_IN_COOPERATION)
-    @Override
-    public Response updateInvitation(Long apartmentId,
-                                     Long id,
-                                     UpdateApartmentInvitation updateApartmentInvitation) {
-        var updateInvitationDto = mapper.convert(updateApartmentInvitation,
-                ApartmentInvitationDto.class);
-        var toUpdate = invitationService.updateInvitation(apartmentId, id, updateInvitationDto);
-        var readInvitation = mapper.convert(toUpdate, ReadApartmentInvitation.class);
-        return Response.status(Response.Status.OK).entity(readInvitation).build();
     }
 
     @PreAuthorize(MANAGE_IN_COOPERATION)

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/cooperation/invitation/enums/InvitationStatus.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/cooperation/invitation/enums/InvitationStatus.java
@@ -13,10 +13,6 @@ public enum InvitationStatus {
 
     ACCEPTED("accepted"),
 
-    DECLINED("declined"),
-
-    DEACTIVATED("deactivated"),
-
     OVERDUE("overdue"),
 
     ERROR("error");

--- a/home-docs/home-api-tests.md
+++ b/home-docs/home-api-tests.md
@@ -5,16 +5,6 @@ There are several options on how to run home-api-tests.
 - Use terminal command 'mvn clean install' with api-tests and api-tests-infrastructure profiles. 
   Also path database and application admin-user credentials.
 Terminal command should look like this:
-  
-  `mvn clean install
-  -Pjacoco
-  -Papi-tests-infrastructure
-  -Papi-tests
-  -Dpostgres.user={your main postgres superuser}
-  -Dpostgres.password={your postgres superuser password}
-  -Dhome.application.admin.username={your application admin username}
-  -Dhome.application.admin.password={your application admin password}
-  -Dapi.tests.verbose.logging=false`
 
   
 - Run home-application, add mentioned above variables to your Junit template VM options,

--- a/home-docs/home-api-tests.md
+++ b/home-docs/home-api-tests.md
@@ -2,21 +2,31 @@
 
 There are several options on how to run home-api-tests.
 
-- Use terminal command 'mvn clean install' with api-tests and api-tests-infrastructure profiles. 
+- Use terminal command 'mvn clean install' with api-tests and api-tests-infrastructure profiles.
   Also path database and application admin-user credentials.
-Terminal command should look like this:
+  Terminal command should look like this:
 
-  
+  `mvn clean install
+  -Pjacoco
+  -Papi-tests-infrastructure
+  -Papi-tests
+  -Dpostgres.user={your main postgres superuser}
+  -Dpostgres.password={your postgres superuser password}
+  -Dhome.application.admin.username={your application admin username}
+  -Dhome.application.admin.password={your application admin password}
+  -Dapi.tests.verbose.logging=false`
+
+
 - Run home-application, add mentioned above variables to your Junit template VM options,
-  
+
   as well as your home-application external port.
   This will allow to run each test separately.
   Don't forget to run home-data-migration after making database schema changes.
   Junit template VM options should look like this:
-  
-  `-ea 
-  -Dhome.application.external.port={your home-application external port} 
-  -Dpostgres.user={your postgres superuser} 
-  -Dpostgres.password={your postgres superuser password} 
+
+  `-ea
+  -Dhome.application.external.port={your home-application external port}
+  -Dpostgres.user={your postgres superuser}
+  -Dpostgres.password={your postgres superuser password}
   -Dhome.application.admin.username={your application admin username}
   -Dhome.application.admin.password={your application admin password}`

--- a/home-open-api/src/main/resources/yaml/models/invitation.yaml
+++ b/home-open-api/src/main/resources/yaml/models/invitation.yaml
@@ -13,9 +13,7 @@ InvitationStatus:
     - pending
     - processing
     - accepted
-    - declined
     - overdue
-    - deactivated
     - error
 InvitationType:
   description: Indicates a type of an Invitation

--- a/home-open-api/src/main/resources/yaml/models/invitation.yaml
+++ b/home-open-api/src/main/resources/yaml/models/invitation.yaml
@@ -123,16 +123,3 @@ UpdateInvitation:
 UpdateCooperationInvitation:
   allOf:
     - $ref: '#/UpdateInvitation'
-UpdateApartmentInvitation:
-  allOf:
-    - $ref: '#/UpdateInvitation'
-  type: object
-  required:
-    - ownership_part
-  properties:
-    ownership_part:
-      type: number
-      minimum: 0.0001
-      maximum: 1.0
-      multipleOf: 1e-4
-      example: 0.6588

--- a/home-open-api/src/main/resources/yaml/paths/apartmentInvitations.yaml
+++ b/home-open-api/src/main/resources/yaml/paths/apartmentInvitations.yaml
@@ -69,30 +69,6 @@ apartments-apartmentId-invitations-invitationId:
         $ref: '../responses/responses.yaml#/NotFound'
       default:
         $ref: '../responses/responses.yaml#/InternalServerError'
-  put:
-    tags:
-      - apartment invitation
-    summary: Update invitation
-    description: The endpoint updates an invitation for an apartment owner by ID. Email can be updated with Invitation status 'pending' only
-    operationId: updateInvitation
-    parameters:
-      - $ref: '../parameters/parameters.yaml#/p_apartment_id'
-      - $ref: '../parameters/parameters.yaml#/p_invitation_id'
-    requestBody:
-      $ref: '../requests/requestBodies.yaml#/UpdateApartmentInvitationBody'
-    responses:
-      200:
-        $ref: '../responses/responses.yaml#/ApartmentInvitationResponse'
-      400:
-        $ref: '../responses/responses.yaml#/BadRequest'
-      401:
-        $ref: '../responses/responses.yaml#/Unauthorized'
-      403:
-        $ref: '../responses/responses.yaml#/Forbidden'
-      404:
-        $ref: '../responses/responses.yaml#/NotFound'
-      default:
-        $ref: '../responses/responses.yaml#/InternalServerError'
   delete:
     tags:
       - apartment invitation

--- a/home-open-api/src/main/resources/yaml/requests/requestBodies.yaml
+++ b/home-open-api/src/main/resources/yaml/requests/requestBodies.yaml
@@ -109,13 +109,6 @@ CreateApartmentInvitationBody:
     application/json:
       schema:
         $ref: '../models/invitation.yaml#/CreateApartmentInvitation'
-UpdateApartmentInvitationBody:
-  description: A payload for updating an invitation for the apartment owner
-  content:
-    application/json:
-      schema:
-        $ref: '../models/invitation.yaml#/UpdateApartmentInvitation'
-  required: true
 CreatePollBody:
   description: A payload for creating a new cooperation poll
   content:

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/cooperation/invitation/enums/InvitationStatusDto.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/cooperation/invitation/enums/InvitationStatusDto.java
@@ -8,10 +8,6 @@ public enum InvitationStatusDto {
 
     ACCEPTED("accepted"),
 
-    DECLINED("declined"),
-
-    DEACTIVATED("deactivated"),
-
     OVERDUE("overdue"),
 
     ERROR("error");

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/invitation/apartment/ApartmentInvitationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/invitation/apartment/ApartmentInvitationServiceImpl.java
@@ -179,8 +179,9 @@ public class ApartmentInvitationServiceImpl extends InvitationServiceImpl implem
     @Override
     public void deactivateInvitationById(Long apartmentId, Long id) {
         ApartmentInvitation apartmentInvitation = apartmentInvitationRepository.findById(id)
-            .filter(invitation -> invitation.getEnabled().equals(true)
-                && invitation.getApartment().getId().equals(apartmentId))
+            .filter(invitation -> invitation.getEnabled() != null
+                    & invitation.getEnabled().equals(true)
+                    & invitation.getApartment().getId().equals(apartmentId))
             .orElseThrow(() ->
                 new NotFoundHomeException("Invitation with id:" + id + "not found."));
         if (apartmentInvitation.getStatus().equals(InvitationStatus.ACCEPTED)) {

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/invitation/apartment/ApartmentInvitationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/invitation/apartment/ApartmentInvitationServiceImpl.java
@@ -21,6 +21,7 @@ import com.softserveinc.ita.homeproject.homedata.user.ownership.OwnershipReposit
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.InvitationDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.apartment.ApartmentInvitationDto;
 import com.softserveinc.ita.homeproject.homeservice.exception.BadRequestHomeException;
+import com.softserveinc.ita.homeproject.homeservice.exception.InvitationException;
 import com.softserveinc.ita.homeproject.homeservice.exception.NotFoundHomeException;
 import com.softserveinc.ita.homeproject.homeservice.mapper.ServiceMapper;
 import com.softserveinc.ita.homeproject.homeservice.service.cooperation.invitation.InvitationServiceImpl;
@@ -177,15 +178,15 @@ public class ApartmentInvitationServiceImpl extends InvitationServiceImpl implem
 
     @Override
     public void deactivateInvitationById(Long apartmentId, Long id) {
-        var apartmentInvitation = apartmentInvitationRepository.findById(id)
-            .filter(invitation -> invitation.getSentDatetime() == null
-                && invitation.getEnabled().equals(true)
-                && invitation.getApartment().getId().equals(apartmentId)
-                && invitation.getStatus().equals(InvitationStatus.PENDING))
+        ApartmentInvitation apartmentInvitation = apartmentInvitationRepository.findById(id)
+            .filter(invitation -> invitation.getEnabled().equals(true)
+                && invitation.getApartment().getId().equals(apartmentId))
             .orElseThrow(() ->
                 new NotFoundHomeException("Invitation with id:" + id + "not found."));
+        if (apartmentInvitation.getStatus().equals(InvitationStatus.ACCEPTED)) {
+            throw new BadRequestHomeException("Deactivating invitations with status ACCEPTED is forbidden");
+        }
         apartmentInvitation.setEnabled(false);
-        apartmentInvitation.setStatus(InvitationStatus.DEACTIVATED);
         apartmentInvitationRepository.save(apartmentInvitation);
     }
 

--- a/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ApartmentInvitationServiceIntegrationTest.java
+++ b/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ApartmentInvitationServiceIntegrationTest.java
@@ -37,10 +37,6 @@ public class ApartmentInvitationServiceIntegrationTest {
         apartmentInvitationRepository.save(createOverdueProcessingApartmentInvitation());
         apartmentInvitationRepository.save(createNotOverdueAcceptedApartmentInvitation());
         apartmentInvitationRepository.save(createOverdueAcceptedApartmentInvitation());
-        apartmentInvitationRepository.save(createNotOverdueDeclinedApartmentInvitation());
-        apartmentInvitationRepository.save(createOverdueDeclinedApartmentInvitation());
-        apartmentInvitationRepository.save(createNotOverdueDeactivatedApartmentInvitation());
-        apartmentInvitationRepository.save(createOverdueDeactivatedApartmentInvitation());
         apartmentInvitationRepository.save(createOverdueApartmentInvitation());
         apartmentInvitationRepository.save(createNotOverdueErrorApartmentInvitation());
         apartmentInvitationRepository.save(createOverdueErrorApartmentInvitation());
@@ -107,34 +103,6 @@ public class ApartmentInvitationServiceIntegrationTest {
     private ApartmentInvitation createOverdueAcceptedApartmentInvitation() {
         var invitation = new ApartmentInvitation();
         invitation.setStatus(InvitationStatus.ACCEPTED);
-        invitation.setRequestEndTime(LocalDateTime.now().minusDays(1));
-        return invitation;
-    }
-
-    private ApartmentInvitation createNotOverdueDeclinedApartmentInvitation() {
-        var invitation = new ApartmentInvitation();
-        invitation.setStatus(InvitationStatus.DECLINED);
-        invitation.setRequestEndTime(LocalDateTime.now().plusDays(1));
-        return invitation;
-    }
-
-    private ApartmentInvitation createOverdueDeclinedApartmentInvitation() {
-        var invitation = new ApartmentInvitation();
-        invitation.setStatus(InvitationStatus.DECLINED);
-        invitation.setRequestEndTime(LocalDateTime.now().minusDays(1));
-        return invitation;
-    }
-
-    private ApartmentInvitation createNotOverdueDeactivatedApartmentInvitation() {
-        var invitation = new ApartmentInvitation();
-        invitation.setStatus(InvitationStatus.DEACTIVATED);
-        invitation.setRequestEndTime(LocalDateTime.now().plusDays(1));
-        return invitation;
-    }
-
-    private ApartmentInvitation createOverdueDeactivatedApartmentInvitation() {
-        var invitation = new ApartmentInvitation();
-        invitation.setStatus(InvitationStatus.DEACTIVATED);
         invitation.setRequestEndTime(LocalDateTime.now().minusDays(1));
         return invitation;
     }

--- a/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ApartmentInvitationServiceIntegrationTest.java
+++ b/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ApartmentInvitationServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.softserveinc.ita.homeproject.homeservice.service.impl;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDateTime;
@@ -7,10 +8,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import com.softserveinc.ita.homeproject.homedata.cooperation.apatment.Apartment;
+import com.softserveinc.ita.homeproject.homedata.cooperation.apatment.ApartmentRepository;
 import com.softserveinc.ita.homeproject.homedata.cooperation.invitation.apartment.ApartmentInvitation;
 import com.softserveinc.ita.homeproject.homedata.cooperation.invitation.enums.InvitationStatus;
 import com.softserveinc.ita.homeproject.homedata.cooperation.invitation.apartment.ApartmentInvitationRepository;
 import com.softserveinc.ita.homeproject.homeservice.HomeServiceTestContextConfig;
+import com.softserveinc.ita.homeproject.homeservice.exception.BadRequestHomeException;
 import com.softserveinc.ita.homeproject.homeservice.service.cooperation.invitation.apartment.ApartmentInvitationServiceImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationInvitationServiceIntegrationTest.java
+++ b/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationInvitationServiceIntegrationTest.java
@@ -37,10 +37,6 @@ public class CooperationInvitationServiceIntegrationTest {
         cooperationInvitationRepository.save(createOverdueProcessingCooperationInvitation());
         cooperationInvitationRepository.save(createNotOverdueAcceptedCooperationInvitation());
         cooperationInvitationRepository.save(createOverdueAcceptedCooperationInvitation());
-        cooperationInvitationRepository.save(createNotOverdueDeclinedCooperationInvitation());
-        cooperationInvitationRepository.save(createOverdueDeclinedCooperationInvitation());
-        cooperationInvitationRepository.save(createNotOverdueDeactivatedCooperationInvitation());
-        cooperationInvitationRepository.save(createOverdueDeactivatedCooperationInvitation());
         cooperationInvitationRepository.save(createOverdueCooperationInvitation());
         cooperationInvitationRepository.save(createNotOverdueErrorCooperationInvitation());
         cooperationInvitationRepository.save(createOverdueErrorCooperationInvitation());
@@ -106,34 +102,6 @@ public class CooperationInvitationServiceIntegrationTest {
     private CooperationInvitation createOverdueAcceptedCooperationInvitation() {
         var invitation = new CooperationInvitation();
         invitation.setStatus(InvitationStatus.ACCEPTED);
-        invitation.setRequestEndTime(LocalDateTime.now().minusDays(1));
-        return invitation;
-    }
-
-    private CooperationInvitation createNotOverdueDeclinedCooperationInvitation() {
-        var invitation = new CooperationInvitation();
-        invitation.setStatus(InvitationStatus.DECLINED);
-        invitation.setRequestEndTime(LocalDateTime.now().plusDays(1));
-        return invitation;
-    }
-
-    private CooperationInvitation createOverdueDeclinedCooperationInvitation() {
-        var invitation = new CooperationInvitation();
-        invitation.setStatus(InvitationStatus.DECLINED);
-        invitation.setRequestEndTime(LocalDateTime.now().minusDays(1));
-        return invitation;
-    }
-
-    private CooperationInvitation createNotOverdueDeactivatedCooperationInvitation() {
-        var invitation = new CooperationInvitation();
-        invitation.setStatus(InvitationStatus.DEACTIVATED);
-        invitation.setRequestEndTime(LocalDateTime.now().plusDays(1));
-        return invitation;
-    }
-
-    private CooperationInvitation createOverdueDeactivatedCooperationInvitation() {
-        var invitation = new CooperationInvitation();
-        invitation.setStatus(InvitationStatus.DEACTIVATED);
         invitation.setRequestEndTime(LocalDateTime.now().minusDays(1));
         return invitation;
     }


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/335)


## Code reviewers

- [ ] @bbogdasha 
- [ ] @kh0ma 
- [ ] @DzigMS 
- [ ] @varhanovdm 

## Summary of issue

We should delete status DEACTIVATED, declined for invitations, and allow delete invitation in all status except accepted.
Decomission PUT /apartments/{apartment_id}/invitations/{id}

## Summary of change

DEACTIVATED and DECLINED statuses for invitations are removed from project. All invitations except ACCEPTED can be deleted.
Update endpoint for apartments' invitations is also removed

## Testing approach

Testing for deleting invitations will be implemented in the task 300

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
