### PR TITLE
Issue#334 Remove 'ownership_part' from ApartmentInvitation

### DIFF
--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartments/ApartmentApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartments/ApartmentApiIT.java
@@ -128,18 +128,6 @@ class ApartmentApiIT {
     }
 
     @Test
-    void createApartmentWithInvalidAreaOwner() throws ApiException {
-        ReadCooperation readCooperation = cooperationApi.createCooperation(createCooperation());
-        ReadHouse readHouse = houseApi.createHouse(readCooperation.getId(), createHouse());
-        CreateApartment createApartment = createApartment().invitations(createInvalidApartmentInvitation());
-
-        assertThatExceptionOfType(ApiException.class)
-                .isThrownBy(() -> apartmentApi.createApartment(readHouse.getId(), createApartment))
-                .matches((actual) -> actual.getCode() == BAD_REQUEST)
-                .withMessageContaining("The sum of the entered area of the apartment = 1.5. Area cannot be greater than 1");
-    }
-
-    @Test
     void createApartmentInvalidApartmentNumber() throws ApiException {
         ReadCooperation readCooperation = cooperationApi.createCooperation(createCooperation());
         ReadHouse readHouse = houseApi.createHouse(readCooperation.getId(), createHouse());
@@ -298,27 +286,10 @@ class ApartmentApiIT {
     private List<CreateInvitation> createApartmentInvitation() {
         List<CreateInvitation> createInvitations = new ArrayList<>();
         createInvitations.add(new CreateApartmentInvitation()
-                .ownershipPart(BigDecimal.valueOf(0.3))
                 .email("test.receive.messages@gmail.com")
                 .type(InvitationType.APARTMENT));
 
         createInvitations.add(new CreateApartmentInvitation()
-                .ownershipPart(BigDecimal.valueOf(0.7))
-                .email("test.receive.messages@gmail.com")
-                .type(InvitationType.APARTMENT));
-
-        return createInvitations;
-    }
-
-    private List<CreateInvitation> createInvalidApartmentInvitation() {
-        List<CreateInvitation> createInvitations = new ArrayList<>();
-        createInvitations.add(new CreateApartmentInvitation()
-                .ownershipPart(BigDecimal.valueOf(0.8))
-                .email("test.receive.messages@gmail.com")
-                .type(InvitationType.APARTMENT));
-
-        createInvitations.add(new CreateApartmentInvitation()
-                .ownershipPart(BigDecimal.valueOf(0.7))
                 .email("test.receive.messages@gmail.com")
                 .type(InvitationType.APARTMENT));
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartments/QueryApartmentIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartments/QueryApartmentIT.java
@@ -191,12 +191,10 @@ class QueryApartmentIT {
     private List<CreateInvitation> createApartmentInvitation() {
         List<CreateInvitation> createInvitations = new ArrayList<>();
         createInvitations.add(new CreateApartmentInvitation()
-                .ownershipPart(BigDecimal.valueOf(0.3))
                 .email("test.receive.messages@gmail.com")
                 .type(InvitationType.APARTMENT));
 
         createInvitations.add(new CreateApartmentInvitation()
-                .ownershipPart(BigDecimal.valueOf(0.7))
                 .email("test.receive.messages@gmail.com")
                 .type(InvitationType.APARTMENT));
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/InvitationApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/InvitationApiIT.java
@@ -210,7 +210,6 @@ class InvitationApiIT {
     private List<CreateInvitation> createApartmentInvitationWithEmail(String userEmail) {
         List<CreateInvitation> createInvitations = new ArrayList<>();
         createInvitations.add(new CreateApartmentInvitation()
-                .ownershipPart(BigDecimal.valueOf(0.3))
                 .email( userEmail)
                 .type(InvitationType.APARTMENT));
         return createInvitations;

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/ownerships/OwnershipApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/ownerships/OwnershipApiIT.java
@@ -247,7 +247,6 @@ class OwnershipApiIT {
     private List<CreateInvitation> createApartmentInvitation() {
         List<CreateInvitation> createInvitations = new ArrayList<>();
         createInvitations.add(new CreateApartmentInvitation()
-                .ownershipPart(BigDecimal.valueOf(0.3))
                 .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"))
                 .type(InvitationType.APARTMENT));
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/security/PermissionsIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/security/PermissionsIT.java
@@ -616,12 +616,10 @@ class PermissionsIT {
     private static List<CreateInvitation> createListOfInvitation() {
         List<CreateInvitation> createInvitations = new ArrayList<>();
         createInvitations.add(new CreateApartmentInvitation()
-            .ownershipPart(BigDecimal.valueOf(0.1))
             .email("test.receive.messages@gmail.com")
             .type(InvitationType.APARTMENT));
 
         createInvitations.add(new CreateApartmentInvitation()
-            .ownershipPart(BigDecimal.valueOf(0.1))
             .email("test.receive.messages@gmail.com")
             .type(InvitationType.APARTMENT));
 
@@ -630,14 +628,12 @@ class PermissionsIT {
 
     private static CreateApartmentInvitation createApartmentInvitation() {
         return (CreateApartmentInvitation) new CreateApartmentInvitation()
-            .ownershipPart(BigDecimal.valueOf(0.1))
             .email("test.receive.messages@gmail.com")
             .type(InvitationType.APARTMENT);
     }
 
     private static UpdateApartmentInvitation updateApartmentInvitation() {
         return new UpdateApartmentInvitation()
-            .ownershipPart(BigDecimal.valueOf(1))
             .email("test.receive.messages@gmail.com");
     }
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
@@ -244,7 +244,6 @@ public final class ApiClientUtil {
     private static List<CreateInvitation> createApartmentInvitation() {
         List<CreateInvitation> createInvitations = new ArrayList<>();
         createInvitations.add(new CreateApartmentInvitation()
-                .ownershipPart(BigDecimal.valueOf(0.3))
                 .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"))
                 .type(InvitationType.APARTMENT));
 

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/ApartmentApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/ApartmentApiImpl.java
@@ -93,7 +93,6 @@ public class ApartmentApiImpl extends CommonApi implements ApartmentsApi {
                                     String filter,
                                     Long id,
                                     String email,
-                                    BigDecimal ownershipPart,
                                     String status) {
         verifyExistence(apartmentId, apartmentService);
         Page<ApartmentInvitationDto> readApartmentInvitation = invitationService

--- a/home-data-migration/src/main/resources/db/changelog/0.0.1/Issue334.xml
+++ b/home-data-migration/src/main/resources/db/changelog/0.0.1/Issue334.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet id="Issue334.001" author="varhanovdm">
+        <dropColumn tableName="invitations">
+            <column name="ownership_part"/>
+        </dropColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/home-data-migration/src/main/resources/db/changelog/0.0.1/_cumulative.xml
+++ b/home-data-migration/src/main/resources/db/changelog/0.0.1/_cumulative.xml
@@ -25,4 +25,5 @@
     <include file="Issue304.xml" relativeToChangelogFile="true"/>
     <include file="Issue313.xml" relativeToChangelogFile="true"/>
     <include file="Issue324.xml" relativeToChangelogFile="true"/>
+    <include file="Issue334.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/cooperation/invitation/apartment/ApartmentInvitation.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/cooperation/invitation/apartment/ApartmentInvitation.java
@@ -1,7 +1,5 @@
 package com.softserveinc.ita.homeproject.homedata.cooperation.invitation.apartment;
 
-import java.math.BigDecimal;
-import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
@@ -18,10 +16,8 @@ import lombok.Setter;
 @DiscriminatorValue("apartment")
 public class ApartmentInvitation extends Invitation {
 
-    @Column(name = "ownership_part")
-    private BigDecimal ownershipPart;
-
     @ManyToOne
     @JoinColumn(name = "apartment_id")
     private Apartment apartment;
 }
+

--- a/home-open-api/src/main/resources/yaml/models/apartment.yaml
+++ b/home-open-api/src/main/resources/yaml/models/apartment.yaml
@@ -23,13 +23,11 @@ CreateApartment:
       example: [
         {
           "email": "test.receive.messages@gmail.com",
-          "type": "apartment",
-          "ownership_part": 0.3
+          "type": "apartment"
         },
         {
           "email": "test.receive.messages@gmail.com",
-          "type": "apartment",
-          "ownership_part": 0.7
+          "type": "apartment"
         }
       ]
 UpdateApartment:

--- a/home-open-api/src/main/resources/yaml/models/invitation.yaml
+++ b/home-open-api/src/main/resources/yaml/models/invitation.yaml
@@ -54,14 +54,6 @@ ReadCooperationInvitation:
 ReadApartmentInvitation:
   allOf:
     - $ref: '#/ReadInvitation'
-  type: object
-  properties:
-    ownership_part:
-      type: number
-      minimum: 0.0001
-      maximum: 1.0
-      multipleOf: 1e-4
-      example: 0.6588
 Role:
   description: User role
   type: string
@@ -98,16 +90,6 @@ CreateCooperationInvitation:
 CreateApartmentInvitation:
   allOf:
     - $ref: '#/CreateInvitation'
-  type: object
-  required:
-    - ownership_part
-  properties:
-    ownership_part:
-      type: number
-      minimum: 0.0001
-      maximum: 1.0
-      multipleOf: 1e-4
-      example: 0.6588
 
 UpdateInvitation:
   type: object
@@ -126,13 +108,4 @@ UpdateCooperationInvitation:
 UpdateApartmentInvitation:
   allOf:
     - $ref: '#/UpdateInvitation'
-  type: object
-  required:
-    - ownership_part
-  properties:
-    ownership_part:
-      type: number
-      minimum: 0.0001
-      maximum: 1.0
-      multipleOf: 1e-4
-      example: 0.6588
+

--- a/home-open-api/src/main/resources/yaml/paths/apartmentInvitations.yaml
+++ b/home-open-api/src/main/resources/yaml/paths/apartmentInvitations.yaml
@@ -13,7 +13,6 @@ apartments-apartmentId-invitations:
       - $ref: '../parameters/parameters.yaml#/filter'
       - $ref: '../parameters/parameters.yaml#/id'
       - $ref: '../parameters/parameters.yaml#/email'
-      - $ref: '../parameters/parameters.yaml#/ownership_part'
       - $ref: '../parameters/parameters.yaml#/status'
     responses:
       200:

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/cooperation/invitation/apartment/ApartmentInvitationDto.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/cooperation/invitation/apartment/ApartmentInvitationDto.java
@@ -1,7 +1,5 @@
 package com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.apartment;
 
-import java.math.BigDecimal;
-
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.InvitationDto;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,8 +7,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ApartmentInvitationDto extends InvitationDto {
-
-    private BigDecimal ownershipPart;
 
     private String apartmentNumber;
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/apartment/ApartmentServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/apartment/ApartmentServiceImpl.java
@@ -1,6 +1,5 @@
 package com.softserveinc.ita.homeproject.homeservice.service.cooperation.apartment;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -50,16 +49,6 @@ public class ApartmentServiceImpl implements ApartmentService {
 
         var house = houseRepository.findById(houseId).filter(House::getEnabled)
             .orElseThrow(() -> new NotFoundHomeException(String.format(HOUSE_WITH_ID_NOT_FOUND, houseId)));
-
-        BigDecimal invitationSummaryOwnerPart =
-            createApartmentDto.getInvitations().stream().map(ApartmentInvitationDto::getOwnershipPart)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-
-        if (invitationSummaryOwnerPart.compareTo(BigDecimal.valueOf(1)) > 0) {
-            throw new BadRequestHomeException(
-                "The sum of the entered area of the apartment = " + invitationSummaryOwnerPart
-                    + ". Area cannot be greater than 1");
-        }
 
         var apartment = mapper.convert(createApartmentDto, Apartment.class);
         List<ApartmentInvitationDto> invitations = createApartmentDto.getInvitations();

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/email/SendApartmentEmailService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/email/SendApartmentEmailService.java
@@ -1,5 +1,6 @@
 package com.softserveinc.ita.homeproject.homeservice.service.general.email;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.InvitationDto;
@@ -37,7 +38,7 @@ public class SendApartmentEmailService extends BaseEmailService {
         mailDto.setEmail(invitation.getEmail());
         mailDto.setRegistrationToken(invitation.getRegistrationToken());
         mailDto.setApartmentNumber(invitation.getApartmentNumber());
-        mailDto.setOwnershipPat(invitation.getOwnershipPart());
+        mailDto.setOwnershipPat(BigDecimal.ZERO);
         checkRegistration(invitation, mailDto);
         return mailDto;
     }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/user/ownership/OwnershipServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/user/ownership/OwnershipServiceImpl.java
@@ -3,8 +3,6 @@ package com.softserveinc.ita.homeproject.homeservice.service.user.ownership;
 import java.math.BigDecimal;
 
 import com.softserveinc.ita.homeproject.homedata.cooperation.invitation.apartment.ApartmentInvitation;
-import com.softserveinc.ita.homeproject.homedata.cooperation.invitation.apartment.ApartmentInvitationRepository;
-import com.softserveinc.ita.homeproject.homedata.cooperation.invitation.enums.InvitationStatus;
 import com.softserveinc.ita.homeproject.homedata.user.UserRepository;
 import com.softserveinc.ita.homeproject.homedata.user.ownership.Ownership;
 import com.softserveinc.ita.homeproject.homedata.user.ownership.OwnershipRepository;
@@ -27,8 +25,6 @@ public class OwnershipServiceImpl implements OwnershipService {
 
     private final UserRepository userRepository;
 
-    private final ApartmentInvitationRepository invitationRepository;
-
     private final ServiceMapper mapper;
 
     private static final String OWNERSHIP_WITH_ID_NOT_FOUND = "Ownership with 'id: %d' is not found";
@@ -36,7 +32,7 @@ public class OwnershipServiceImpl implements OwnershipService {
     @Override
     public Ownership createOwnership(ApartmentInvitation apartmentInvitation) {
         var ownership = new Ownership();
-        ownership.setOwnershipPart(apartmentInvitation.getOwnershipPart());
+        ownership.setOwnershipPart(BigDecimal.ZERO);
         ownership.setApartment(apartmentInvitation.getApartment());
         ownership.setCooperation(apartmentInvitation.getApartment().getHouse().getCooperation());
 
@@ -89,18 +85,11 @@ public class OwnershipServiceImpl implements OwnershipService {
     }
 
     public void validateSumOwnershipPart(Long apartmentId, Ownership toUpdate, OwnershipDto updateOwnershipDto) {
-        BigDecimal activeInvitationsSumOwnerPart = invitationRepository
-                .findAllByApartmentIdAndStatus(apartmentId, InvitationStatus.PENDING)
-                .stream()
-                .map(ApartmentInvitation::getOwnershipPart)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-
         BigDecimal sumOfOwnerPartsWithNewInput = ownershipRepository.findAllByApartmentId(apartmentId)
                 .stream()
                 .filter(Ownership::getEnabled)
                 .map(Ownership::getOwnershipPart)
                 .reduce(BigDecimal.ZERO, BigDecimal::add)
-                .add(activeInvitationsSumOwnerPart)
                 .subtract(toUpdate.getOwnershipPart())
                 .add(updateOwnershipDto.getOwnershipPart());
 


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/334)


## Code reviewers

- [ ] @bbogdasha 
- [ ] @MrScors 

## Summary of issue

We need to remove the 'ownership_part' parameter in Apartments invitation and all validation. We must set 'ownership_part' to zero when we create an invitation to an apartment.

## Summary of change

Deleted all usages of ApartmentInvitation -> ownership_part and changed set 'ownership_part' value to zero by default.

## Testing approach

Reworked

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
