### PR TITLE
Issue#335 deleted status deactivated, declined

### DIFF
--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/security/PermissionsIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/security/PermissionsIT.java
@@ -30,7 +30,6 @@ import com.softserveinc.ita.homeproject.client.model.QuestionType;
 import com.softserveinc.ita.homeproject.client.model.ReadCooperation;
 import com.softserveinc.ita.homeproject.client.model.ReadVote;
 import com.softserveinc.ita.homeproject.client.model.UpdateApartment;
-import com.softserveinc.ita.homeproject.client.model.UpdateApartmentInvitation;
 import com.softserveinc.ita.homeproject.client.model.UpdateContact;
 import com.softserveinc.ita.homeproject.client.model.UpdateCooperation;
 import com.softserveinc.ita.homeproject.client.model.UpdateEmailContact;
@@ -383,8 +382,6 @@ class PermissionsIT {
                 return createBaseCooperation();
             case "com.softserveinc.ita.homeproject.client.model.CreateApartmentInvitation":
                 return createApartmentInvitation();
-            case "com.softserveinc.ita.homeproject.client.model.UpdateApartmentInvitation":
-                return updateApartmentInvitation();
             case "com.softserveinc.ita.homeproject.client.model.InvitationToken":
                 return getInvitationToken();
             default:
@@ -633,12 +630,6 @@ class PermissionsIT {
             .ownershipPart(BigDecimal.valueOf(0.1))
             .email("test.receive.messages@gmail.com")
             .type(InvitationType.APARTMENT);
-    }
-
-    private static UpdateApartmentInvitation updateApartmentInvitation() {
-        return new UpdateApartmentInvitation()
-            .ownershipPart(BigDecimal.valueOf(1))
-            .email("test.receive.messages@gmail.com");
     }
 
     private static CreateApartment createApartment() {

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/ApartmentApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/ApartmentApiImpl.java
@@ -12,7 +12,6 @@ import com.softserveinc.ita.homeproject.application.model.CreateApartmentInvitat
 import com.softserveinc.ita.homeproject.application.model.InvitationType;
 import com.softserveinc.ita.homeproject.application.model.ReadApartmentInvitation;
 import com.softserveinc.ita.homeproject.application.model.ReadOwnership;
-import com.softserveinc.ita.homeproject.application.model.UpdateApartmentInvitation;
 import com.softserveinc.ita.homeproject.application.model.UpdateOwnership;
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.apartment.ApartmentInvitationDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.user.ownership.OwnershipDto;
@@ -114,18 +113,6 @@ public class ApartmentApiImpl extends CommonApi implements ApartmentsApi {
         verifyExistence(apartmentId, apartmentService);
         Page<OwnershipDto> readOwnership = ownershipService.findAll(pageNumber, pageSize, getSpecification());
         return buildQueryResponse(readOwnership, ReadOwnership.class);
-    }
-
-    @PreAuthorize(MANAGE_IN_COOPERATION)
-    @Override
-    public Response updateInvitation(Long apartmentId,
-                                     Long id,
-                                     UpdateApartmentInvitation updateApartmentInvitation) {
-        var updateInvitationDto = mapper.convert(updateApartmentInvitation,
-            ApartmentInvitationDto.class);
-        var toUpdate = invitationService.updateInvitation(apartmentId, id, updateInvitationDto);
-        var readInvitation = mapper.convert(toUpdate, ReadApartmentInvitation.class);
-        return Response.status(Response.Status.OK).entity(readInvitation).build();
     }
 
     @PreAuthorize(MANAGE_IN_COOPERATION)

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/cooperation/invitation/enums/InvitationStatus.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/cooperation/invitation/enums/InvitationStatus.java
@@ -13,10 +13,6 @@ public enum InvitationStatus {
 
     ACCEPTED("accepted"),
 
-    DECLINED("declined"),
-
-    DEACTIVATED("deactivated"),
-
     OVERDUE("overdue"),
 
     ERROR("error");

--- a/home-open-api/src/main/resources/yaml/models/invitation.yaml
+++ b/home-open-api/src/main/resources/yaml/models/invitation.yaml
@@ -13,9 +13,7 @@ InvitationStatus:
     - pending
     - processing
     - accepted
-    - declined
     - overdue
-    - deactivated
     - error
 InvitationType:
   description: Indicates a type of an Invitation

--- a/home-open-api/src/main/resources/yaml/models/invitation.yaml
+++ b/home-open-api/src/main/resources/yaml/models/invitation.yaml
@@ -121,16 +121,3 @@ UpdateInvitation:
 UpdateCooperationInvitation:
   allOf:
     - $ref: '#/UpdateInvitation'
-UpdateApartmentInvitation:
-  allOf:
-    - $ref: '#/UpdateInvitation'
-  type: object
-  required:
-    - ownership_part
-  properties:
-    ownership_part:
-      type: number
-      minimum: 0.0001
-      maximum: 1.0
-      multipleOf: 1e-4
-      example: 0.6588

--- a/home-open-api/src/main/resources/yaml/paths/apartmentInvitations.yaml
+++ b/home-open-api/src/main/resources/yaml/paths/apartmentInvitations.yaml
@@ -69,30 +69,6 @@ apartments-apartmentId-invitations-invitationId:
         $ref: '../responses/responses.yaml#/NotFound'
       default:
         $ref: '../responses/responses.yaml#/InternalServerError'
-  put:
-    tags:
-      - apartment invitation
-    summary: Update invitation
-    description: The endpoint updates an invitation for an apartment owner by ID. Email can be updated with Invitation status 'pending' only
-    operationId: updateInvitation
-    parameters:
-      - $ref: '../parameters/parameters.yaml#/p_apartment_id'
-      - $ref: '../parameters/parameters.yaml#/p_invitation_id'
-    requestBody:
-      $ref: '../requests/requestBodies.yaml#/UpdateApartmentInvitationBody'
-    responses:
-      200:
-        $ref: '../responses/responses.yaml#/ApartmentInvitationResponse'
-      400:
-        $ref: '../responses/responses.yaml#/BadRequest'
-      401:
-        $ref: '../responses/responses.yaml#/Unauthorized'
-      403:
-        $ref: '../responses/responses.yaml#/Forbidden'
-      404:
-        $ref: '../responses/responses.yaml#/NotFound'
-      default:
-        $ref: '../responses/responses.yaml#/InternalServerError'
   delete:
     tags:
       - apartment invitation

--- a/home-open-api/src/main/resources/yaml/requests/requestBodies.yaml
+++ b/home-open-api/src/main/resources/yaml/requests/requestBodies.yaml
@@ -109,13 +109,6 @@ CreateApartmentInvitationBody:
     application/json:
       schema:
         $ref: '../models/invitation.yaml#/CreateApartmentInvitation'
-UpdateApartmentInvitationBody:
-  description: A payload for updating an invitation for the apartment owner
-  content:
-    application/json:
-      schema:
-        $ref: '../models/invitation.yaml#/UpdateApartmentInvitation'
-  required: true
 CreatePollBody:
   description: A payload for creating a new cooperation poll
   content:

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/cooperation/invitation/enums/InvitationStatusDto.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/cooperation/invitation/enums/InvitationStatusDto.java
@@ -8,10 +8,6 @@ public enum InvitationStatusDto {
 
     ACCEPTED("accepted"),
 
-    DECLINED("declined"),
-
-    DEACTIVATED("deactivated"),
-
     OVERDUE("overdue"),
 
     ERROR("error");

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/invitation/apartment/ApartmentInvitationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/invitation/apartment/ApartmentInvitationServiceImpl.java
@@ -185,7 +185,6 @@ public class ApartmentInvitationServiceImpl extends InvitationServiceImpl implem
             .orElseThrow(() ->
                 new NotFoundHomeException("Invitation with id:" + id + "not found."));
         apartmentInvitation.setEnabled(false);
-        apartmentInvitation.setStatus(InvitationStatus.DEACTIVATED);
         apartmentInvitationRepository.save(apartmentInvitation);
     }
 

--- a/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ApartmentInvitationServiceIntegrationTest.java
+++ b/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/ApartmentInvitationServiceIntegrationTest.java
@@ -37,10 +37,6 @@ public class ApartmentInvitationServiceIntegrationTest {
         apartmentInvitationRepository.save(createOverdueProcessingApartmentInvitation());
         apartmentInvitationRepository.save(createNotOverdueAcceptedApartmentInvitation());
         apartmentInvitationRepository.save(createOverdueAcceptedApartmentInvitation());
-        apartmentInvitationRepository.save(createNotOverdueDeclinedApartmentInvitation());
-        apartmentInvitationRepository.save(createOverdueDeclinedApartmentInvitation());
-        apartmentInvitationRepository.save(createNotOverdueDeactivatedApartmentInvitation());
-        apartmentInvitationRepository.save(createOverdueDeactivatedApartmentInvitation());
         apartmentInvitationRepository.save(createOverdueApartmentInvitation());
         apartmentInvitationRepository.save(createNotOverdueErrorApartmentInvitation());
         apartmentInvitationRepository.save(createOverdueErrorApartmentInvitation());
@@ -107,34 +103,6 @@ public class ApartmentInvitationServiceIntegrationTest {
     private ApartmentInvitation createOverdueAcceptedApartmentInvitation() {
         var invitation = new ApartmentInvitation();
         invitation.setStatus(InvitationStatus.ACCEPTED);
-        invitation.setRequestEndTime(LocalDateTime.now().minusDays(1));
-        return invitation;
-    }
-
-    private ApartmentInvitation createNotOverdueDeclinedApartmentInvitation() {
-        var invitation = new ApartmentInvitation();
-        invitation.setStatus(InvitationStatus.DECLINED);
-        invitation.setRequestEndTime(LocalDateTime.now().plusDays(1));
-        return invitation;
-    }
-
-    private ApartmentInvitation createOverdueDeclinedApartmentInvitation() {
-        var invitation = new ApartmentInvitation();
-        invitation.setStatus(InvitationStatus.DECLINED);
-        invitation.setRequestEndTime(LocalDateTime.now().minusDays(1));
-        return invitation;
-    }
-
-    private ApartmentInvitation createNotOverdueDeactivatedApartmentInvitation() {
-        var invitation = new ApartmentInvitation();
-        invitation.setStatus(InvitationStatus.DEACTIVATED);
-        invitation.setRequestEndTime(LocalDateTime.now().plusDays(1));
-        return invitation;
-    }
-
-    private ApartmentInvitation createOverdueDeactivatedApartmentInvitation() {
-        var invitation = new ApartmentInvitation();
-        invitation.setStatus(InvitationStatus.DEACTIVATED);
         invitation.setRequestEndTime(LocalDateTime.now().minusDays(1));
         return invitation;
     }

--- a/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationInvitationServiceIntegrationTest.java
+++ b/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/CooperationInvitationServiceIntegrationTest.java
@@ -37,10 +37,6 @@ public class CooperationInvitationServiceIntegrationTest {
         cooperationInvitationRepository.save(createOverdueProcessingCooperationInvitation());
         cooperationInvitationRepository.save(createNotOverdueAcceptedCooperationInvitation());
         cooperationInvitationRepository.save(createOverdueAcceptedCooperationInvitation());
-        cooperationInvitationRepository.save(createNotOverdueDeclinedCooperationInvitation());
-        cooperationInvitationRepository.save(createOverdueDeclinedCooperationInvitation());
-        cooperationInvitationRepository.save(createNotOverdueDeactivatedCooperationInvitation());
-        cooperationInvitationRepository.save(createOverdueDeactivatedCooperationInvitation());
         cooperationInvitationRepository.save(createOverdueCooperationInvitation());
         cooperationInvitationRepository.save(createNotOverdueErrorCooperationInvitation());
         cooperationInvitationRepository.save(createOverdueErrorCooperationInvitation());
@@ -106,34 +102,6 @@ public class CooperationInvitationServiceIntegrationTest {
     private CooperationInvitation createOverdueAcceptedCooperationInvitation() {
         var invitation = new CooperationInvitation();
         invitation.setStatus(InvitationStatus.ACCEPTED);
-        invitation.setRequestEndTime(LocalDateTime.now().minusDays(1));
-        return invitation;
-    }
-
-    private CooperationInvitation createNotOverdueDeclinedCooperationInvitation() {
-        var invitation = new CooperationInvitation();
-        invitation.setStatus(InvitationStatus.DECLINED);
-        invitation.setRequestEndTime(LocalDateTime.now().plusDays(1));
-        return invitation;
-    }
-
-    private CooperationInvitation createOverdueDeclinedCooperationInvitation() {
-        var invitation = new CooperationInvitation();
-        invitation.setStatus(InvitationStatus.DECLINED);
-        invitation.setRequestEndTime(LocalDateTime.now().minusDays(1));
-        return invitation;
-    }
-
-    private CooperationInvitation createNotOverdueDeactivatedCooperationInvitation() {
-        var invitation = new CooperationInvitation();
-        invitation.setStatus(InvitationStatus.DEACTIVATED);
-        invitation.setRequestEndTime(LocalDateTime.now().plusDays(1));
-        return invitation;
-    }
-
-    private CooperationInvitation createOverdueDeactivatedCooperationInvitation() {
-        var invitation = new CooperationInvitation();
-        invitation.setStatus(InvitationStatus.DEACTIVATED);
         invitation.setRequestEndTime(LocalDateTime.now().minusDays(1));
         return invitation;
     }


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009)

## Code reviewers

- [ ] @MrScors 
- [ ] @bbogdasha
- [ ] @Sorex1992 
- [ ] @varhanovdm 
- [ ] @VladyslavZhigir 

## Summary of issue 

We should delete status DEACTIVATED, declined for invitations

## Summary of change

Deleted in Enum InvitationStatusDto, InvitationStatus status DEACTIVATED, DECLINED. Edited methods where this enum was used.

## Testing approach

Reworked

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
