### PR TITLE
Bug/issue#408   able to create vote for poll wihch is outdated

### DIFF
--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/polls/PollVoteApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/polls/PollVoteApiIT.java
@@ -73,6 +73,8 @@ class PollVoteApiIT {
 
     private static final String QUESTION_NOT_FOUND_MESSAGE = "Poll question with 'id: %d' is not found";
 
+    private static final String POLL_COMPLETION_DATE_VALIDATION_MESSAGE = "Can't create vote on outdated poll: '%s'";
+
     private static final PollStatus[] POLL_STATUSES_WITHOUT_ACTIVE_AND_COMPLETED =
             {PollStatus.DRAFT, PollStatus.SUSPENDED};
 
@@ -162,6 +164,35 @@ class PollVoteApiIT {
                 .isThrownBy(() -> pollVoteApi.createVoteWithHttpInfo(createdPoll.getId(), createdVote))
                 .matches(exception -> exception.getCode() == BAD_REQUEST)
                 .withMessageContaining(String.format(POLL_STATUS_VALIDATION_MESSAGE, createdPoll.getStatus()));
+    }
+
+    @Test
+    void votingOnExpiredPollThrowsExceptionTest() throws ApiException {
+        ReadCooperation createdCooperation = cooperationApi.createCooperation(createCooperation());
+        ReadPoll createdPoll = cooperationPollApi.createCooperationPoll(createdCooperation.getId(),
+            new CreatePoll()
+            .header(String.format("Poll #%d for vote test", ++pollNumber))
+            .type(PollType.SIMPLE)
+            .creationDate(LocalDateTime.now()
+                .minusDays(16L)
+                .truncatedTo(ChronoUnit.MINUTES))
+            .completionDate(LocalDateTime.now()
+                .minusDays(1L))
+            .description("Description"));
+        CreateAdviceQuestion createdAdviceQuestion = createAdviceQuestion();
+        ReadAdviceQuestion addedAdviceQuestion = (ReadAdviceQuestion)
+
+            pollQuestionApi.createQuestion(createdPoll.getId(), createdAdviceQuestion);
+        createdPoll.setStatus(PollStatus.ACTIVE);
+        cooperationPollApi.updateCooperationPoll(createdCooperation.getId(), createdPoll.getId(),
+            updatePoll(createdPoll));
+
+        CreateVote createdVote = new CreateVote().addQuestionVotesItem(createAdviceQuestionVote(addedAdviceQuestion));
+
+        assertThatExceptionOfType(ApiException.class)
+            .isThrownBy(() -> pollVoteApi.createVoteWithHttpInfo(createdPoll.getId(), createdVote))
+            .matches(exception -> exception.getCode() == BAD_REQUEST)
+            .withMessageContaining(String.format(POLL_COMPLETION_DATE_VALIDATION_MESSAGE, createdPoll.getCompletionDate()));
     }
 
     @Test

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/polls/PollVoteApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/polls/PollVoteApiIT.java
@@ -169,8 +169,7 @@ class PollVoteApiIT {
     @Test
     void votingOnExpiredPollThrowsExceptionTest() throws ApiException {
         ReadCooperation createdCooperation = cooperationApi.createCooperation(createCooperation());
-        ReadPoll createdPoll = cooperationPollApi.createCooperationPoll(createdCooperation.getId(),
-            new CreatePoll()
+        CreatePoll createdPoll = new CreatePoll()
             .header(String.format("Poll #%d for vote test", ++pollNumber))
             .type(PollType.SIMPLE)
             .creationDate(LocalDateTime.now()
@@ -178,21 +177,22 @@ class PollVoteApiIT {
                 .truncatedTo(ChronoUnit.MINUTES))
             .completionDate(LocalDateTime.now()
                 .minusDays(1L))
-            .description("Description"));
+            .description("Description");
+        ReadPoll createPoll = cooperationPollApi.createCooperationPoll(createdCooperation.getId(), createdPoll);
         CreateAdviceQuestion createdAdviceQuestion = createAdviceQuestion();
         ReadAdviceQuestion addedAdviceQuestion = (ReadAdviceQuestion)
 
-            pollQuestionApi.createQuestion(createdPoll.getId(), createdAdviceQuestion);
-        createdPoll.setStatus(PollStatus.ACTIVE);
-        cooperationPollApi.updateCooperationPoll(createdCooperation.getId(), createdPoll.getId(),
-            updatePoll(createdPoll));
+            pollQuestionApi.createQuestion(createPoll.getId(), createdAdviceQuestion);
+        createPoll.setStatus(PollStatus.ACTIVE);
+        cooperationPollApi.updateCooperationPoll(createdCooperation.getId(), createPoll.getId(),
+            updatePoll(createPoll));
 
         CreateVote createdVote = new CreateVote().addQuestionVotesItem(createAdviceQuestionVote(addedAdviceQuestion));
 
         assertThatExceptionOfType(ApiException.class)
-            .isThrownBy(() -> pollVoteApi.createVoteWithHttpInfo(createdPoll.getId(), createdVote))
+            .isThrownBy(() -> pollVoteApi.createVoteWithHttpInfo(createPoll.getId(), createdVote))
             .matches(exception -> exception.getCode() == BAD_REQUEST)
-            .withMessageContaining(String.format(POLL_COMPLETION_DATE_VALIDATION_MESSAGE, createdPoll.getCompletionDate()));
+            .withMessageContaining(String.format(POLL_COMPLETION_DATE_VALIDATION_MESSAGE, createPoll.getCompletionDate()));
     }
 
     @Test


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

Update VoteServiceImpl.java createVote() method logic
to remove the ability of users to vote for outdated Votes
Cover this logic with IT tests

## Summary of change

* VoteServiceImpl:
  * created method which validate poll complition date during `createVote()`
  * declared method `validateCompletionDateTime()` calling from `createVote()`
 
* VoteApiIT:
  * created testcase which throws expected exception during creation vote on poll with outdated complition date

## Testing approach



## CHECK LIST
- [x]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
