### PR TITLE
Feature/issue#404 poll result calculation

### DIFF
--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/poll_questions/QueryQuestionIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/poll_questions/QueryQuestionIT.java
@@ -22,6 +22,7 @@ import com.softserveinc.ita.homeproject.client.api.PollQuestionApi;
 import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.CreateAdviceQuestion;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateDoubleChoiceQuestion;
 import com.softserveinc.ita.homeproject.client.model.CreateMultipleChoiceQuestion;
 import com.softserveinc.ita.homeproject.client.model.CreatePoll;
 import com.softserveinc.ita.homeproject.client.model.CreateQuestion;
@@ -51,7 +52,7 @@ class QueryQuestionIT {
 
         pollQuestionApi.createQuestion(readPoll.getId(), createAdviceQuestion());
         pollQuestionApi.createQuestion(readPoll.getId(), createMultipleChoiceQuestion());
-
+        pollQuestionApi.createQuestion(readPoll.getId(), createDoubleChoiceQuestion());
 
         List<ReadQuestion> queryResponse = new PollQuestionQuery.Builder(pollQuestionApi)
                 .pollId(readPoll.getId())
@@ -70,6 +71,7 @@ class QueryQuestionIT {
 
         pollQuestionApi.createQuestion(readPoll.getId(), createAdviceQuestion());
         pollQuestionApi.createQuestion(readPoll.getId(), createMultipleChoiceQuestion());
+        pollQuestionApi.createQuestion(readPoll.getId(), createDoubleChoiceQuestion());
 
 
         List<ReadQuestion> queryResponse = new PollQuestionQuery.Builder(pollQuestionApi)
@@ -149,6 +151,12 @@ class QueryQuestionIT {
                 .answerVariants(createAnswerVariants())
                 .type(QuestionType.MULTIPLE_CHOICE)
                 .question("What color should we paint the door?");
+    }
+
+    private static CreateQuestion createDoubleChoiceQuestion() {
+        return new CreateDoubleChoiceQuestion()
+                .type(QuestionType.DOUBLE_CHOICE)
+                .question("Should we paint the door?");
     }
 
     private static List<CreateUpdateAnswerVariant> createAnswerVariants() {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/poll_questions/QuestionApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/poll_questions/QuestionApiIT.java
@@ -21,6 +21,7 @@ import com.softserveinc.ita.homeproject.client.api.PollQuestionApi;
 import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.CreateAdviceQuestion;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateDoubleChoiceQuestion;
 import com.softserveinc.ita.homeproject.client.model.CreateMultipleChoiceQuestion;
 import com.softserveinc.ita.homeproject.client.model.CreatePoll;
 import com.softserveinc.ita.homeproject.client.model.CreateQuestion;
@@ -28,9 +29,11 @@ import com.softserveinc.ita.homeproject.client.model.CreateUpdateAnswerVariant;
 import com.softserveinc.ita.homeproject.client.model.PollType;
 import com.softserveinc.ita.homeproject.client.model.QuestionType;
 import com.softserveinc.ita.homeproject.client.model.ReadCooperation;
+import com.softserveinc.ita.homeproject.client.model.ReadDoubleChoiceQuestion;
 import com.softserveinc.ita.homeproject.client.model.ReadMultipleChoiceQuestion;
 import com.softserveinc.ita.homeproject.client.model.ReadPoll;
 import com.softserveinc.ita.homeproject.client.model.ReadQuestion;
+import com.softserveinc.ita.homeproject.client.model.UpdateDoubleChoiceQuestion;
 import com.softserveinc.ita.homeproject.client.model.UpdateMultipleChoiceQuestion;
 import com.softserveinc.ita.homeproject.client.model.UpdateQuestion;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -59,6 +62,20 @@ class QuestionApiIT {
 
         assertQuestion(createQuestion, (ReadMultipleChoiceQuestion) response.getData());
 
+    }
+
+    @Test
+    void createDoubleChoiceQuestionTest() throws ApiException{
+        CreateDoubleChoiceQuestion createQuestion = (CreateDoubleChoiceQuestion) createDoubleChoiceQuestion();
+
+        ReadCooperation createdCooperation = cooperationApi.createCooperation(createCooperation());
+        ReadPoll createdPoll = cooperationPollApi.createCooperationPoll(createdCooperation.getId(), createPoll());
+
+        ApiResponse<ReadQuestion> response = pollQuestionApi.createQuestionWithHttpInfo(createdPoll.getId(), createQuestion);
+
+        assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatusCode());
+
+        assertQuestion(createQuestion, (ReadDoubleChoiceQuestion) response.getData());
     }
 
     @Test
@@ -157,6 +174,25 @@ class QuestionApiIT {
     }
 
     @Test
+    void updateDoubleChoiceQuestionTest() throws ApiException {
+        CreateDoubleChoiceQuestion createQuestion = (CreateDoubleChoiceQuestion) createDoubleChoiceQuestion();
+
+        ReadCooperation createdCooperation = cooperationApi.createCooperation(createCooperation());
+        ReadPoll createdPoll = cooperationPollApi.createCooperationPoll(createdCooperation.getId(), createPoll());
+        ReadQuestion createdQuestion = pollQuestionApi.createQuestion(createdPoll.getId(), createQuestion);
+
+        UpdateQuestion updateQuestion = new UpdateDoubleChoiceQuestion()
+            .type(QuestionType.DOUBLE_CHOICE)
+            .question("Do we need this poll");
+
+        ApiResponse<ReadQuestion> response = pollQuestionApi.updateQuestionWithHttpInfo(createdPoll.getId(), createdQuestion.getId(), updateQuestion);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+
+        assertDoubleQuestion(createdQuestion, (UpdateDoubleChoiceQuestion) updateQuestion, (ReadDoubleChoiceQuestion) response.getData());
+    }
+
+    @Test
     void updateNonExistentQuestion() throws ApiException {
         ReadCooperation createdCooperation = cooperationApi.createCooperation(createCooperation());
         ReadPoll createdPoll = cooperationPollApi.createCooperationPoll(createdCooperation.getId(), createPoll());
@@ -215,6 +251,12 @@ class QuestionApiIT {
                 .answerVariants(createAnswerVariants())
                 .type(QuestionType.MULTIPLE_CHOICE)
                 .question("What color should we paint the door?");
+    }
+
+    private static CreateQuestion createDoubleChoiceQuestion() {
+        return new CreateDoubleChoiceQuestion()
+            .type(QuestionType.DOUBLE_CHOICE)
+            .question("Should we paint the wall?");
     }
 
     private static List<CreateUpdateAnswerVariant> createAnswerVariants() {
@@ -304,6 +346,14 @@ class QuestionApiIT {
         assertEquals(update.getType(), updated.getType());
         assertAnswer(update, updated);
 
+    }
+
+    private void assertDoubleQuestion(ReadQuestion saved, UpdateDoubleChoiceQuestion update, ReadDoubleChoiceQuestion updated) {
+        assertNotNull(saved);
+        assertNotNull(update);
+        assertNotNull(updated);
+        assertEquals(update.getQuestion(), updated.getQuestion());
+        assertEquals(update.getType(), updated.getType());
     }
 
     private void assertAnswer(UpdateMultipleChoiceQuestion update,ReadMultipleChoiceQuestion updated) {

--- a/home-data-migration/src/main/resources/db/changelog/0.0.1/Issue404.xml
+++ b/home-data-migration/src/main/resources/db/changelog/0.0.1/Issue404.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet id="Issue404.001" author="vladyslavyarets">
+        <addColumn tableName="polls">
+            <column name="result" type="varchar(255)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/home-data-migration/src/main/resources/db/changelog/0.0.1/_cumulative.xml
+++ b/home-data-migration/src/main/resources/db/changelog/0.0.1/_cumulative.xml
@@ -27,4 +27,5 @@
     <include file="Issue324.xml" relativeToChangelogFile="true"/>
     <include file="Issue334.xml" relativeToChangelogFile="true"/>
     <include file="Issue390.xml" relativeToChangelogFile="true"/>
+    <include file="Issue404.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/Poll.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/Poll.java
@@ -70,4 +70,7 @@ public class Poll extends BaseEntity {
 
     @OneToMany(mappedBy = "poll", cascade = CascadeType.PERSIST)
     private List<PollQuestion> pollQuestions;
+
+    @Column(name = "result")
+    private String result;
 }

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/converters/PollQuestionTypeAttributeConverter.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/converters/PollQuestionTypeAttributeConverter.java
@@ -17,6 +17,9 @@ public class PollQuestionTypeAttributeConverter implements AttributeConverter<Po
                 return "advice";
             case MULTIPLE_CHOICE:
                 return "multiple_choice";
+            case DOUBLE_CHOICE:
+                return "double_choice";
+
             default:
                 throw new IllegalArgumentException(attribute + " not supported.");
         }
@@ -33,6 +36,9 @@ public class PollQuestionTypeAttributeConverter implements AttributeConverter<Po
                 return PollQuestionType.ADVICE;
             case "multiple_choice":
                 return PollQuestionType.MULTIPLE_CHOICE;
+            case "double_choice":
+                return PollQuestionType.DOUBLE_CHOICE;
+
             default:
                 throw new IllegalArgumentException(dbData + " not supported.");
         }

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/enums/PollQuestionType.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/enums/PollQuestionType.java
@@ -4,7 +4,9 @@ public enum  PollQuestionType {
 
     ADVICE("advice"),
 
-    MULTIPLE_CHOICE("multiple_choice");
+    MULTIPLE_CHOICE("multiple_choice"),
+
+    DOUBLE_CHOICE("double_choice");
 
     private String value;
 

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/enums/PollType.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/enums/PollType.java
@@ -1,7 +1,9 @@
 package com.softserveinc.ita.homeproject.homedata.poll.enums;
 
 public enum PollType {
-    SIMPLE("simple");
+    SIMPLE("simple"),
+
+    MAJOR("major");
 
     private final String value;
 

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/question/AnswerVariant.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/question/AnswerVariant.java
@@ -8,11 +8,7 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 import com.softserveinc.ita.homeproject.homedata.BaseEntity;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 @Getter

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/question/AnswerVariant.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/question/AnswerVariant.java
@@ -8,7 +8,11 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 import com.softserveinc.ita.homeproject.homedata.BaseEntity;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 @Getter

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/question/DoubleChoiceQuestion.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/question/DoubleChoiceQuestion.java
@@ -1,0 +1,14 @@
+package com.softserveinc.ita.homeproject.homedata.poll.question;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@DiscriminatorValue("double_choice")
+public class DoubleChoiceQuestion extends MultipleChoiceQuestion{
+}

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/votes/QuestionVoteRepository.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/votes/QuestionVoteRepository.java
@@ -1,7 +1,11 @@
 package com.softserveinc.ita.homeproject.homedata.poll.votes;
 
+import com.softserveinc.ita.homeproject.homedata.poll.question.PollQuestion;
+import org.aspectj.weaver.patterns.TypePatternQuestions;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 /**
  * QuestionVoteRepository is the interface that is needed
@@ -11,4 +15,6 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface QuestionVoteRepository extends PagingAndSortingRepository<QuestionVote, Long> {
+    List<QuestionVote> findAllByQuestion(PollQuestion question);
+
 }

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/votes/QuestionVoteRepository.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/votes/QuestionVoteRepository.java
@@ -3,7 +3,6 @@ package com.softserveinc.ita.homeproject.homedata.poll.votes;
 import java.util.List;
 
 import com.softserveinc.ita.homeproject.homedata.poll.question.PollQuestion;
-import org.aspectj.weaver.patterns.TypePatternQuestions;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/votes/QuestionVoteRepository.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/votes/QuestionVoteRepository.java
@@ -1,11 +1,11 @@
 package com.softserveinc.ita.homeproject.homedata.poll.votes;
 
+import java.util.List;
+
 import com.softserveinc.ita.homeproject.homedata.poll.question.PollQuestion;
 import org.aspectj.weaver.patterns.TypePatternQuestions;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 /**
  * QuestionVoteRepository is the interface that is needed

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/votes/VoteQuestionVariantRepository.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/votes/VoteQuestionVariantRepository.java
@@ -1,5 +1,7 @@
 package com.softserveinc.ita.homeproject.homedata.poll.votes;
 
+import java.util.List;
+
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +13,5 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface VoteQuestionVariantRepository extends PagingAndSortingRepository<VoteQuestionVariant, Long> {
+    VoteQuestionVariant findByQuestionVote(QuestionVote questionVote);
 }

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/votes/VoteQuestionVariantRepository.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/votes/VoteQuestionVariantRepository.java
@@ -1,7 +1,5 @@
 package com.softserveinc.ita.homeproject.homedata.poll.votes;
 
-import java.util.List;
-
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 

--- a/home-open-api/src/main/resources/yaml/models/poll.yaml
+++ b/home-open-api/src/main/resources/yaml/models/poll.yaml
@@ -73,6 +73,9 @@ ReadPoll:
       $ref: '#/PollStatus'
     type:
       $ref: '#/PollType'
+    result:
+      type: string
+      example: "The result of the poll"
 CreatePoll:
   type: object
   required:

--- a/home-open-api/src/main/resources/yaml/models/poll.yaml
+++ b/home-open-api/src/main/resources/yaml/models/poll.yaml
@@ -12,6 +12,7 @@ PollType:
   type: string
   enum: &poll_type_values
     - simple
+    - major
   example: "simple"
 
 ReadPoll:

--- a/home-open-api/src/main/resources/yaml/models/question.yaml
+++ b/home-open-api/src/main/resources/yaml/models/question.yaml
@@ -3,6 +3,7 @@ QuestionType:
   type: string
   enum: &question_type_values
     - multiple_choice
+    - double_choice
     - advice
   example: "advice"
 QuestionLookup:
@@ -21,6 +22,7 @@ ReadQuestion:
     propertyName: type
     mapping:
       multiple_choice: '#/ReadMultipleChoiceQuestion'
+      double_choise_question: '#/ReadDoubleChoiceQuestion'
       advice: '#/ReadAdviceQuestion'
   properties:
     type:
@@ -55,6 +57,32 @@ ReadMultipleChoiceQuestion:
       minimum: 1
       maximum: 100
       example: 5
+ReadDoubleChoiceQuestion:
+  allOf:
+    - $ref: '#/ReadQuestion'
+  type: object
+  properties:
+    answer_variants:
+      type: array
+      minItems: 2
+      maxItems: 2
+      items:
+        $ref: 'answer.yaml#/ReadAnswerVariant'
+      example: [
+        {
+          "id": 1,
+          "answer": "yes"
+        },
+        {
+          'id': 2,
+          "answer": "no"
+        }
+      ]
+    max_answer_count:
+      type: integer
+      minimum: 1
+      maximum: 1
+      example: 1
 ReadAdviceQuestion:
   allOf:
     - $ref: '#/ReadQuestion'
@@ -66,6 +94,7 @@ CreateQuestion:
     propertyName: type
     mapping:
       multiple_choice: '#/CreateMultipleChoiceQuestion'
+      double_choice: '#/CreateDoubleChoiceQuestion'
       advice: '#/CreateAdviceQuestion'
   required:
     - type
@@ -104,6 +133,10 @@ CreateMultipleChoiceQuestion:
       minimum: 1
       maximum: 100
       example: 5
+CreateDoubleChoiceQuestion:
+  allOf:
+    - $ref: '#/CreateQuestion'
+  type: object
 CreateAdviceQuestion:
   allOf:
     - $ref: '#/CreateQuestion'
@@ -115,6 +148,7 @@ UpdateQuestion:
     propertyName: type
     mapping:
       multiple_choice: '#/UpdateMultipleChoiceQuestion'
+      double_choice: '#/UpdateDoubleChoiceQuestion'
       advice: '#/UpdateAdviceQuestion'
   required:
     - type
@@ -153,6 +187,9 @@ UpdateMultipleChoiceQuestion:
       minimum: 1
       maximum: 100
       example: 5
+UpdateDoubleChoiceQuestion:
+  allOf:
+    - $ref: '#/UpdateQuestion'
 UpdateAdviceQuestion:
   allOf:
     - $ref: '#/UpdateQuestion'

--- a/home-open-api/src/main/resources/yaml/models/question.yaml
+++ b/home-open-api/src/main/resources/yaml/models/question.yaml
@@ -22,7 +22,7 @@ ReadQuestion:
     propertyName: type
     mapping:
       multiple_choice: '#/ReadMultipleChoiceQuestion'
-      double_choise_question: '#/ReadDoubleChoiceQuestion'
+      double_choice: '#/ReadDoubleChoiceQuestion'
       advice: '#/ReadAdviceQuestion'
   properties:
     type:

--- a/home-open-api/src/main/resources/yaml/models/vote.yaml
+++ b/home-open-api/src/main/resources/yaml/models/vote.yaml
@@ -33,6 +33,7 @@ CreateQuestionVote:
     propertyName: type
     mapping:
       multiple_choice: '#/CreateMultipleChoiceQuestionVote'
+      double_choice: '#/CreateDoubleChoiceQuestionVote'
       advice: '#/CreateAdviceQuestionVote'
   properties:
     type:
@@ -61,7 +62,15 @@ CreateMultipleChoiceQuestionVote:
             "id": 3
           }
         ]
-
+CreateDoubleChoiceQuestionVote:
+  allOf:
+    - $ref: '#/CreateQuestionVote'
+  type: object
+  required:
+    - answer
+  properties:
+    answer:
+      $ref: 'answer.yaml#/CreateUpdateAnswerVariant'
 CreateAdviceQuestionVote:
   allOf:
     - $ref: '#/CreateQuestionVote'

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/poll/PollDto.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/poll/PollDto.java
@@ -27,4 +27,6 @@ public class PollDto extends BaseDto {
     private PollStatusDto status;
 
     private PollTypeDto type;
+
+    private String result;
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/poll/enums/PollQuestionTypeDto.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/poll/enums/PollQuestionTypeDto.java
@@ -4,7 +4,9 @@ public enum PollQuestionTypeDto {
 
     ADVICE("advice"),
 
-    MULTIPLE_CHOICE("multiple_choice");
+    MULTIPLE_CHOICE("multiple_choice"),
+
+    DOUBLE_CHOICE("double_choice");
 
     private String value;
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/poll/enums/PollTypeDto.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/poll/enums/PollTypeDto.java
@@ -1,7 +1,9 @@
 package com.softserveinc.ita.homeproject.homeservice.dto.poll.enums;
 
 public enum PollTypeDto {
-    SIMPLE("simple");
+    SIMPLE("simple"),
+
+    MAJOR("major");
 
     private final String value;
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/poll/question/DoubleChoiceQuestionDto.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/poll/question/DoubleChoiceQuestionDto.java
@@ -1,0 +1,9 @@
+package com.softserveinc.ita.homeproject.homeservice.dto.poll.question;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DoubleChoiceQuestionDto extends MultipleChoiceQuestionDto{
+}

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/PollServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/PollServiceImpl.java
@@ -161,6 +161,14 @@ public class PollServiceImpl implements PollService {
         }
     }
 
+
+    /**
+     * Calculates and saves the result and status to the database
+     * only for the votes specified below. Two possible scenarios
+     * for counting: by the number of voters and by the area of
+     * ownership of those who voted. Does not save the result for
+     * polls that do not have enough votes.
+     */
     public void calculateCompletedPollsResults() {
         List<Poll> polls = new ArrayList<>();
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/PollServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/PollServiceImpl.java
@@ -1,7 +1,13 @@
 package com.softserveinc.ita.homeproject.homeservice.service.poll;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import com.softserveinc.ita.homeproject.homedata.cooperation.Cooperation;
 import com.softserveinc.ita.homeproject.homedata.cooperation.CooperationRepository;
@@ -9,6 +15,17 @@ import com.softserveinc.ita.homeproject.homedata.cooperation.house.House;
 import com.softserveinc.ita.homeproject.homedata.poll.Poll;
 import com.softserveinc.ita.homeproject.homedata.poll.PollRepository;
 import com.softserveinc.ita.homeproject.homedata.poll.enums.PollStatus;
+import com.softserveinc.ita.homeproject.homedata.poll.enums.PollType;
+import com.softserveinc.ita.homeproject.homedata.poll.question.DoubleChoiceQuestion;
+import com.softserveinc.ita.homeproject.homedata.poll.question.PollQuestion;
+import com.softserveinc.ita.homeproject.homedata.poll.results.ResultQuestion;
+import com.softserveinc.ita.homeproject.homedata.poll.results.ResultQuestionRepository;
+import com.softserveinc.ita.homeproject.homedata.poll.votes.MultipleChoiceQuestionVote;
+import com.softserveinc.ita.homeproject.homedata.poll.votes.QuestionVote;
+import com.softserveinc.ita.homeproject.homedata.poll.votes.QuestionVoteRepository;
+import com.softserveinc.ita.homeproject.homedata.poll.votes.VoteQuestionVariant;
+import com.softserveinc.ita.homeproject.homedata.poll.votes.VoteQuestionVariantRepository;
+import com.softserveinc.ita.homeproject.homedata.user.User;
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.house.HouseDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.poll.PollDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.poll.enums.PollStatusDto;
@@ -42,6 +59,10 @@ public class PollServiceImpl implements PollService {
     private final PollRepository pollRepository;
 
     private final CooperationRepository cooperationRepository;
+
+    private final QuestionVoteRepository questionVoteRepository;
+
+    private final VoteQuestionVariantRepository voteQuestionVariantRepository;
 
     private final ServiceMapper mapper;
 
@@ -99,6 +120,7 @@ public class PollServiceImpl implements PollService {
 
     @Override
     public Page<PollDto> findAll(Integer pageNumber, Integer pageSize, Specification<Poll> specification) {
+        calculateCompletedPollsResults();
         specification = specification.and((root, criteriaQuery, criteriaBuilder) -> criteriaBuilder
             .equal(root.get("cooperation").get("enabled"), true));
         return pollRepository.findAll(specification, PageRequest.of(pageNumber - 1, pageSize))
@@ -109,7 +131,7 @@ public class PollServiceImpl implements PollService {
         return cooperationRepository.findById(id).filter(Cooperation::getEnabled)
             .orElseThrow(() -> new NotFoundHomeException(String.format(NOT_FOUND_MESSAGE, "Cooperation", id)));
     }
-
+//TODO
     private void validateCompletionDate(LocalDateTime completionDate, LocalDateTime creationDate) {
         long days = ChronoUnit.DAYS.between(creationDate, completionDate);
         if (days < minPollDurationInDays) {
@@ -140,5 +162,117 @@ public class PollServiceImpl implements PollService {
             throw new BadRequestHomeException(
                 "Poll status can't be changed to 'completed'");
         }
+    }
+
+    private void calculateCompletedPollsResults() {
+        List<Poll> polls = new ArrayList<>();
+
+        pollRepository.findAll().forEach(polls::add);
+        polls.stream()
+            .filter(poll -> poll.getResult() == null)
+            .filter(poll -> poll.getStatus().equals(PollStatus.ACTIVE))
+            .filter(poll -> poll.getCompletionDate().isBefore(LocalDateTime.now()))
+            .filter(poll -> poll.getEnabled().equals(true))
+            .filter(poll -> poll.getPollQuestions().size() == 1)
+            .filter(poll -> poll.getPollQuestions().get(0) instanceof DoubleChoiceQuestion)
+            .forEach(this::calculatePollResult);
+    }
+
+    private void calculatePollResult(Poll poll) {
+        int votesCount = questionVoteRepository.findAllByQuestion(poll.getPollQuestions().get(0)).size();
+        int amountOfNeededPeople = 0;
+        Map<User, BigDecimal> ownedAreaByUser = getAllAreaOwnedByUser(poll);
+        PollQuestion pollQuestion = poll.getPollQuestions().get(0);
+
+        if (poll.getType().equals(PollType.MAJOR)) {
+            amountOfNeededPeople = votesCount / 3 * 2;
+        } else if (poll.getType().equals(PollType.SIMPLE)) {
+            amountOfNeededPeople = votesCount / 2 + 1;
+        }
+
+        if (votesCount >= amountOfNeededPeople) {
+            poll.setStatus(PollStatus.COMPLETED);
+            if (isOverHalfAreaOwner(ownedAreaByUser, poll)) {
+                saveResultByVotesQuantity(pollQuestion);
+            } else {
+                saveResultByOwnershipArea(pollQuestion, ownedAreaByUser);
+            }
+        }
+    }
+
+    private Map<User, BigDecimal> getAllAreaOwnedByUser(Poll poll) {
+        Map<User, BigDecimal> ownedAreaByUser = new HashMap<>();
+        poll.getPolledHouses().forEach(
+            house -> house.getApartments().forEach(
+                apartment -> apartment.getOwnerships().forEach(
+                    ownership -> {
+                        if (ownedAreaByUser.containsKey(ownership.getUser())) {
+                            ownedAreaByUser.replace(ownership.getUser(),
+                                ownedAreaByUser.get(ownership.getUser())
+                                    .add(ownership.getApartment()
+                                        .getApartmentArea())
+                            );
+                        } else {
+                            ownedAreaByUser.put(ownership.getUser(),
+                                (ownership.getOwnershipPart()).multiply(ownership.getApartment().getApartmentArea()));
+                        }
+                    }
+                )
+            )
+        );
+
+        return ownedAreaByUser;
+    }
+
+    private boolean isOverHalfAreaOwner(Map<User, BigDecimal> totalOwnershipsArea, Poll poll) {
+        double halfHouseArea = poll.getPolledHouses().get(0).getHouseArea() / 2;
+
+        for (Map.Entry<User, BigDecimal> entry : totalOwnershipsArea.entrySet()) {
+            if (entry.getValue().doubleValue() >= halfHouseArea) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void saveResultByOwnershipArea(PollQuestion question, Map<User, BigDecimal> totalOwnershipsArea) {
+        List<QuestionVote> votes = questionVoteRepository.findAllByQuestion(question);
+        BigDecimal totalAreaOfPositiveVotes = new BigDecimal(0);
+        BigDecimal votedHouseArea = BigDecimal.valueOf(question.getPoll().getPolledHouses().get(0).getHouseArea());
+
+        for (QuestionVote questionVote : votes) {
+            VoteQuestionVariant voteQuestionVariant = voteQuestionVariantRepository.findByQuestionVote(questionVote);
+            if (voteQuestionVariant.getAnswerVariant().getAnswer().equals("yes")) {
+                totalAreaOfPositiveVotes = totalAreaOfPositiveVotes
+                    .add(totalOwnershipsArea.get(questionVote.getVote().getUser()));
+            }
+        }
+
+        question.getPoll().setResult(String.valueOf(
+                totalAreaOfPositiveVotes
+                    .multiply(new BigDecimal(100))
+                    .divide(votedHouseArea, 10, RoundingMode.CEILING)
+        ));
+        pollRepository.save(question.getPoll());
+    }
+
+    private void saveResultByVotesQuantity(PollQuestion question) {
+        List<QuestionVote> votes = questionVoteRepository.findAllByQuestion(question);
+        BigDecimal positiveAnswers = new BigDecimal(0);
+
+        for (QuestionVote questionVote : votes) {
+            VoteQuestionVariant voteQuestionVariant = voteQuestionVariantRepository.findByQuestionVote(questionVote);
+            if (voteQuestionVariant.getAnswerVariant().getAnswer().equals("yes")) {
+                positiveAnswers = positiveAnswers.add(new BigDecimal(0));
+            }
+        }
+
+        question.getPoll().setResult(String.valueOf(
+            positiveAnswers
+                .multiply(new BigDecimal(100))
+                .divide(BigDecimal.valueOf(votes.size()), 10, RoundingMode.CEILING)
+        ));
+        pollRepository.save(question.getPoll());
     }
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/PollServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/PollServiceImpl.java
@@ -18,9 +18,6 @@ import com.softserveinc.ita.homeproject.homedata.poll.enums.PollStatus;
 import com.softserveinc.ita.homeproject.homedata.poll.enums.PollType;
 import com.softserveinc.ita.homeproject.homedata.poll.question.DoubleChoiceQuestion;
 import com.softserveinc.ita.homeproject.homedata.poll.question.PollQuestion;
-import com.softserveinc.ita.homeproject.homedata.poll.results.ResultQuestion;
-import com.softserveinc.ita.homeproject.homedata.poll.results.ResultQuestionRepository;
-import com.softserveinc.ita.homeproject.homedata.poll.votes.MultipleChoiceQuestionVote;
 import com.softserveinc.ita.homeproject.homedata.poll.votes.QuestionVote;
 import com.softserveinc.ita.homeproject.homedata.poll.votes.QuestionVoteRepository;
 import com.softserveinc.ita.homeproject.homedata.poll.votes.VoteQuestionVariant;
@@ -131,7 +128,7 @@ public class PollServiceImpl implements PollService {
         return cooperationRepository.findById(id).filter(Cooperation::getEnabled)
             .orElseThrow(() -> new NotFoundHomeException(String.format(NOT_FOUND_MESSAGE, "Cooperation", id)));
     }
-//TODO
+
     private void validateCompletionDate(LocalDateTime completionDate, LocalDateTime creationDate) {
         long days = ChronoUnit.DAYS.between(creationDate, completionDate);
         if (days < minPollDurationInDays) {

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/question/PollQuestionServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/question/PollQuestionServiceImpl.java
@@ -100,8 +100,8 @@ public class PollQuestionServiceImpl implements PollQuestionService {
     }
 
     private PollQuestionDto updateQuestion(PollQuestion pollQuestion, PollQuestionDto updatePollQuestionDto) {
-        if (pollQuestion.getType().equals(PollQuestionType.MULTIPLE_CHOICE) ||
-            pollQuestion.getType().equals(PollQuestionType.DOUBLE_CHOICE)) {
+        if (pollQuestion.getType().equals(PollQuestionType.MULTIPLE_CHOICE)
+            || pollQuestion.getType().equals(PollQuestionType.DOUBLE_CHOICE)) {
             return updateMultiChoiceQuestion((MultipleChoiceQuestion) pollQuestion,
                 (MultipleChoiceQuestionDto) updatePollQuestionDto);
         } else if (pollQuestion.getType().equals(PollQuestionType.ADVICE)) {

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/question/PollQuestionServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/question/PollQuestionServiceImpl.java
@@ -100,7 +100,8 @@ public class PollQuestionServiceImpl implements PollQuestionService {
     }
 
     private PollQuestionDto updateQuestion(PollQuestion pollQuestion, PollQuestionDto updatePollQuestionDto) {
-        if (pollQuestion.getType().equals(PollQuestionType.MULTIPLE_CHOICE)) {
+        if (pollQuestion.getType().equals(PollQuestionType.MULTIPLE_CHOICE) ||
+            pollQuestion.getType().equals(PollQuestionType.DOUBLE_CHOICE)) {
             return updateMultiChoiceQuestion((MultipleChoiceQuestion) pollQuestion,
                 (MultipleChoiceQuestionDto) updatePollQuestionDto);
         } else if (pollQuestion.getType().equals(PollQuestionType.ADVICE)) {

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/question/PollQuestionServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/question/PollQuestionServiceImpl.java
@@ -51,9 +51,7 @@ public class PollQuestionServiceImpl implements PollQuestionService {
         question.setEnabled(true);
         question.setPoll(poll);
         if (question.getType().equals(PollQuestionType.MULTIPLE_CHOICE)) {
-            ((MultipleChoiceQuestion) question).getAnswerVariants().forEach(answer -> {
-                answer.setQuestion(question);
-            });
+            ((MultipleChoiceQuestion) question).getAnswerVariants().forEach(answer -> answer.setQuestion(question));
         }
         if (question.getType().equals(PollQuestionType.DOUBLE_CHOICE)) {
             AnswerVariant positiveAnswer = new AnswerVariant();

--- a/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/PollServiceImplTest.java
+++ b/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/PollServiceImplTest.java
@@ -1,18 +1,38 @@
 package com.softserveinc.ita.homeproject.homeservice.service.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import com.softserveinc.ita.homeproject.homedata.cooperation.Cooperation;
+import com.softserveinc.ita.homeproject.homedata.cooperation.CooperationRepository;
+import com.softserveinc.ita.homeproject.homedata.cooperation.apatment.Apartment;
 import com.softserveinc.ita.homeproject.homedata.cooperation.house.House;
 import com.softserveinc.ita.homeproject.homedata.poll.Poll;
-import com.softserveinc.ita.homeproject.homedata.poll.enums.PollStatus;
-import com.softserveinc.ita.homeproject.homedata.cooperation.CooperationRepository;
 import com.softserveinc.ita.homeproject.homedata.poll.PollRepository;
+import com.softserveinc.ita.homeproject.homedata.poll.enums.PollStatus;
+import com.softserveinc.ita.homeproject.homedata.poll.enums.PollType;
+import com.softserveinc.ita.homeproject.homedata.poll.question.AnswerVariant;
+import com.softserveinc.ita.homeproject.homedata.poll.question.DoubleChoiceQuestion;
+import com.softserveinc.ita.homeproject.homedata.poll.question.PollQuestion;
+import com.softserveinc.ita.homeproject.homedata.poll.votes.MultipleChoiceQuestionVote;
+import com.softserveinc.ita.homeproject.homedata.poll.votes.QuestionVoteRepository;
+import com.softserveinc.ita.homeproject.homedata.poll.votes.Vote;
+import com.softserveinc.ita.homeproject.homedata.poll.votes.VoteQuestionVariant;
+import com.softserveinc.ita.homeproject.homedata.poll.votes.VoteQuestionVariantRepository;
+import com.softserveinc.ita.homeproject.homedata.user.User;
+import com.softserveinc.ita.homeproject.homedata.user.ownership.Ownership;
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.house.HouseDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.poll.PollDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.poll.enums.PollStatusDto;
@@ -35,6 +55,12 @@ class PollServiceImplTest {
 
     @Mock
     private static CooperationRepository cooperationRepository;
+
+    @Mock
+    private static VoteQuestionVariantRepository voteQuestionVariantRepository;
+
+    @Mock
+    private static QuestionVoteRepository questionVoteRepository;
 
     @InjectMocks
     private PollServiceImpl pollService;
@@ -86,5 +112,266 @@ class PollServiceImplTest {
         pollDto.setPolledHouses(Collections.singletonList(houseDto));
         when(cooperationRepository.findById(anyLong())).thenReturn(Optional.of(cooperation));
         assertThrows(NotFoundHomeException.class, () -> pollService.create(1L, pollDto));
+    }
+
+    @Test
+    void calculateCompletedPollsResultsSavesMajorPollResultCalculatedByOwnershipArea() {
+        Poll actualPoll = createPoll();
+        PollQuestion question = actualPoll.getPollQuestions().get(0);
+        List<MultipleChoiceQuestionVote> votes = createQuestionVotes(4, 1);
+        List<VoteQuestionVariant> voteQuestionVariants = createVoteQuestionVariants(votes);
+        actualPoll.setPolledHouses(List.of(createHouse(votes.size())));
+        initializeOwnershipsUser(actualPoll, votes);
+        actualPoll.setType(PollType.MAJOR);
+        question.setPoll(actualPoll);
+        when(questionVoteRepository.findAllByQuestion(actualPoll.getPollQuestions().get(0))).thenReturn(
+            List.copyOf(votes));
+        when(questionVoteRepository.findAllByQuestion(question)).thenReturn(List.copyOf(votes));
+        when(pollRepository.findAll()).thenReturn(List.of(actualPoll));
+        for ( int i = 0; i < votes.size(); i++) {
+            when(voteQuestionVariantRepository.findByQuestionVote(votes.get(i))).thenReturn(voteQuestionVariants.get(i));
+        }
+
+        pollService.calculateCompletedPollsResults();
+
+        verify(pollRepository, times(1)).save(actualPoll);
+        assertEquals("75.0000000000", actualPoll.getResult());
+        assertEquals(PollStatus.COMPLETED, actualPoll.getStatus());
+    }
+
+    @Test
+    void calculateCompletedPollsResultsSavesMajorPollResultCalculatedByVotesQuantity() {
+        Poll actualPoll = createPoll();
+        PollQuestion question = actualPoll.getPollQuestions().get(0);
+        List<MultipleChoiceQuestionVote> votes = createQuestionVotes(6, 1);
+        List<VoteQuestionVariant> voteQuestionVariants = createVoteQuestionVariants(votes);
+        actualPoll.setPolledHouses(List.of(createHouse(2)));
+        initializeOwnershipsUser(actualPoll, votes);
+        actualPoll.setType(PollType.MAJOR);
+        question.setPoll(actualPoll);
+        when(questionVoteRepository.findAllByQuestion(actualPoll.getPollQuestions().get(0))).thenReturn(
+            List.copyOf(votes));
+        when(questionVoteRepository.findAllByQuestion(question)).thenReturn(List.copyOf(votes));
+        when(pollRepository.findAll()).thenReturn(List.of(actualPoll));
+        for ( int i = 0; i < votes.size(); i++) {
+            when(voteQuestionVariantRepository.findByQuestionVote(votes.get(i))).thenReturn(voteQuestionVariants.get(i));
+        }
+
+        pollService.calculateCompletedPollsResults();
+
+        verify(pollRepository, times(1)).save(actualPoll);
+        assertEquals("83.3333333334", actualPoll.getResult());
+        assertEquals(PollStatus.COMPLETED, actualPoll.getStatus());
+    }
+
+    @Test
+    void calculateCompletedPollsResultsSavesSimplePollResultCalculatedByOwnershipArea() {
+        Poll actualPoll = createPoll();
+        PollQuestion question = actualPoll.getPollQuestions().get(0);
+        List<MultipleChoiceQuestionVote> votes = createQuestionVotes(3, 1);
+        List<VoteQuestionVariant> voteQuestionVariants = createVoteQuestionVariants(votes);
+        actualPoll.setPolledHouses(List.of(createHouse(4)));
+        initializeOwnershipsUser(actualPoll, votes);
+        actualPoll.setType(PollType.SIMPLE);
+        question.setPoll(actualPoll);
+        when(questionVoteRepository.findAllByQuestion(actualPoll.getPollQuestions().get(0))).thenReturn(
+            List.copyOf(votes));
+        when(questionVoteRepository.findAllByQuestion(question)).thenReturn(List.copyOf(votes));
+        when(pollRepository.findAll()).thenReturn(List.of(actualPoll));
+        for ( int i = 0; i < votes.size(); i++) {
+            when(voteQuestionVariantRepository.findByQuestionVote(votes.get(i))).thenReturn(voteQuestionVariants.get(i));
+        }
+
+        pollService.calculateCompletedPollsResults();
+
+        verify(pollRepository, times(1)).save(actualPoll);
+        assertEquals("66.6666666667", actualPoll.getResult());
+        assertEquals(PollStatus.COMPLETED, actualPoll.getStatus());
+    }
+
+    @Test
+    void calculateCompletedPollsResultsSavesSimplePollResultCalculatedByVotesQuantity() {
+        Poll actualPoll = createPoll();
+        PollQuestion question = actualPoll.getPollQuestions().get(0);
+        List<MultipleChoiceQuestionVote> votes = createQuestionVotes(4, 2);
+        List<VoteQuestionVariant> voteQuestionVariants = createVoteQuestionVariants(votes);
+        actualPoll.setPolledHouses(List.of(createHouse(2)));
+        initializeOwnershipsUser(actualPoll, votes);
+        actualPoll.setType(PollType.SIMPLE);
+        question.setPoll(actualPoll);
+        when(questionVoteRepository.findAllByQuestion(actualPoll.getPollQuestions().get(0))).thenReturn(
+            List.copyOf(votes));
+        when(questionVoteRepository.findAllByQuestion(question)).thenReturn(List.copyOf(votes));
+        when(pollRepository.findAll()).thenReturn(List.of(actualPoll));
+        for ( int i = 0; i < votes.size(); i++) {
+            when(voteQuestionVariantRepository.findByQuestionVote(votes.get(i))).thenReturn(voteQuestionVariants.get(i));
+        }
+
+        pollService.calculateCompletedPollsResults();
+
+        verify(pollRepository, times(1)).save(actualPoll);
+        assertEquals("50.0000000000", actualPoll.getResult());
+        assertEquals(PollStatus.COMPLETED, actualPoll.getStatus());
+    }
+
+    @Test
+    void calculateCompletedPollsResultsNotSavesResultOfMajorPollWithoutRequiredAmountOfVoters() {
+        Poll actualPoll = createPoll();
+        PollQuestion question = actualPoll.getPollQuestions().get(0);
+        List<MultipleChoiceQuestionVote> votes = createQuestionVotes(2, 1);
+        List<VoteQuestionVariant> voteQuestionVariants = createVoteQuestionVariants(votes);
+        actualPoll.setPolledHouses(List.of(createHouse(5)));
+        initializeOwnershipsUser(actualPoll, votes);
+        actualPoll.setType(PollType.MAJOR);
+        question.setPoll(actualPoll);
+        when(questionVoteRepository.findAllByQuestion(actualPoll.getPollQuestions().get(0))).thenReturn(
+            List.copyOf(votes));
+        when(questionVoteRepository.findAllByQuestion(question)).thenReturn(List.copyOf(votes));
+        for ( int i = 0; i < votes.size(); i++) {
+            when(voteQuestionVariantRepository.findByQuestionVote(votes.get(i))).thenReturn(voteQuestionVariants.get(i));
+        }
+        when(pollRepository.findAll()).thenReturn(List.of(actualPoll));
+
+        pollService.calculateCompletedPollsResults();
+
+        verify(pollRepository, times(1)).save(actualPoll);
+        assertEquals(PollStatus.COMPLETED, actualPoll.getStatus());
+        assertNull(actualPoll.getResult());
+    }
+
+    @Test
+    void calculateCompletedPollsResultsNotSavesResultOfSimplePollWithoutRequiredAmountOfVoters() {
+        Poll actualPoll = createPoll();
+        PollQuestion question = actualPoll.getPollQuestions().get(0);
+        List<MultipleChoiceQuestionVote> votes = createQuestionVotes(2, 2);
+        List<VoteQuestionVariant> voteQuestionVariants = createVoteQuestionVariants(votes);
+        actualPoll.setPolledHouses(List.of(createHouse(5)));
+        initializeOwnershipsUser(actualPoll, votes);
+        actualPoll.setType(PollType.SIMPLE);
+        question.setPoll(actualPoll);
+        when(questionVoteRepository.findAllByQuestion(actualPoll.getPollQuestions().get(0))).thenReturn(
+            List.copyOf(votes));
+        when(questionVoteRepository.findAllByQuestion(question)).thenReturn(List.copyOf(votes));
+        for ( int i = 0; i < votes.size(); i++) {
+            when(voteQuestionVariantRepository.findByQuestionVote(votes.get(i))).thenReturn(voteQuestionVariants.get(i));
+        }
+        when(pollRepository.findAll()).thenReturn(List.of(actualPoll));
+
+        pollService.calculateCompletedPollsResults();
+
+        verify(pollRepository, times(1)).save(actualPoll);
+        assertEquals(PollStatus.COMPLETED, actualPoll.getStatus());
+        assertNull(actualPoll.getResult());
+    }
+
+
+    private static Poll createPoll() {
+        Poll poll = new Poll();
+        DoubleChoiceQuestion question = new DoubleChoiceQuestion();
+        AnswerVariant positiveAnswer = new AnswerVariant();
+        AnswerVariant negativeAnswer = new AnswerVariant();
+
+        positiveAnswer.setAnswer("yes");
+        negativeAnswer.setAnswer("no");
+
+        question.setAnswerVariants(List.of(positiveAnswer, negativeAnswer));
+
+        poll.setStatus(PollStatus.ACTIVE);
+        poll.setCompletionDate(LocalDateTime.now().minusDays(1));
+        poll.setEnabled(true);
+        poll.setPollQuestions(List.of(question));
+
+        return poll;
+    }
+
+    private static House createHouse(int apartmentsQuantity) {
+        House house = new House();
+        List<Apartment> apartments = new ArrayList<>();
+        BigDecimal houseArea = new BigDecimal(0);
+
+        for (int i = 0; i < apartmentsQuantity; i++) {
+            Apartment apartment = createBaseApartment();
+            houseArea = houseArea.add(apartment.getApartmentArea());
+            apartments.add(apartment);
+        }
+
+        house.setHouseArea(houseArea.doubleValue());
+        house.setApartments(apartments);
+
+        return house;
+    }
+
+    private static Apartment createBaseApartment() {
+        Apartment apartment = new Apartment();
+        Ownership ownership = new Ownership();
+
+        ownership.setOwnershipPart(new BigDecimal(1));
+        ownership.setApartment(apartment);
+        apartment.setOwnerships(List.of(ownership));
+        apartment.setApartmentArea(new BigDecimal("100.0"));
+
+        return apartment;
+    }
+
+    private static List<MultipleChoiceQuestionVote> createQuestionVotes(int totalVotesQuantity, int negativeVotes) {
+
+        List<MultipleChoiceQuestionVote> votes = new ArrayList<>();
+        for (int i = 0; i < negativeVotes; i++) {
+            votes.add(createQuestionVote("no"));
+        }
+
+        for (int i = 0; i < (totalVotesQuantity - negativeVotes); i++) {
+            votes.add(createQuestionVote("yes"));
+        }
+
+        return votes;
+    }
+
+    private static MultipleChoiceQuestionVote createQuestionVote(String answer) {
+        MultipleChoiceQuestionVote questionVote = new MultipleChoiceQuestionVote();
+        Vote vote = new Vote();
+        VoteQuestionVariant voteQuestionVariant = new VoteQuestionVariant();
+        AnswerVariant answerVariant = new AnswerVariant();
+
+        vote.setUser(new User());
+        questionVote.setVote(vote);
+        answerVariant.setAnswer(answer);
+        voteQuestionVariant.setAnswerVariant(answerVariant);
+        questionVote.setAnswers(List.of(voteQuestionVariant));
+
+        return questionVote;
+    }
+
+    private static List<VoteQuestionVariant> createVoteQuestionVariants(List<MultipleChoiceQuestionVote> votes) {
+        List<VoteQuestionVariant> voteQuestionVariants = new ArrayList<>();
+
+        for (MultipleChoiceQuestionVote vote : votes) {
+            VoteQuestionVariant voteQuestionVariant = new VoteQuestionVariant();
+            voteQuestionVariant.setQuestionVote(vote);
+            voteQuestionVariant.setAnswerVariant(vote.getAnswers().get(0).getAnswerVariant());
+
+            voteQuestionVariants.add(voteQuestionVariant);
+        }
+
+        return voteQuestionVariants;
+    }
+
+    private static void initializeOwnershipsUser(Poll poll, List<MultipleChoiceQuestionVote> votes) {
+        List<Ownership> ownerships = new ArrayList<>();
+        int lastVoteIndex = votes.size() - 1;
+
+        poll.getPolledHouses().get(0).getApartments().forEach(apartment ->
+            ownerships.addAll(apartment.getOwnerships())
+        );
+
+        for (int i = 0; i < ownerships.size(); i++) {
+            if (i >= lastVoteIndex) {
+                ownerships.get(i).setUser(votes.get(lastVoteIndex).getVote().getUser());
+            } else {
+                ownerships.get(i).setUser(votes.get(i).getVote().getUser());
+            }
+
+            poll.getPolledHouses().get(0).getApartments().get(i).setOwnerships(List.of(ownerships.get(i)));
+        }
     }
 }


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

Add the poll calculation result to the response body field /cooperations/{cooperation_id}/polls. Conditions:
* Poll is active
* Completion date in the past
* Result not yet set
* Poll contains only one question, DoubleChoiceQuestion instance (has only yes/no answer variants).
The result is stored in the database as a string of positive responses.

## Summary of change

Added .xml as a liquibase changeset script (adds result column to the polls table)
Changed .yaml files to implement result field to the response body
Added set of methods to calculate polls result in PollServiceImpl.java
Changed entity and DTO classes of Polls (adds result field)
Created new entity of DoubleChoiceQuestion which extends MultipleChoiceQestion
Added new poll type - Simple
Added testcases

## Testing approach



## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
