### PR TITLE
Feture/issue#426 create changesets for deleting deprecated tables and columns

### DIFF
--- a/home-data-migration/src/main/resources/db/changelog/0.0.1/Issue426.xml
+++ b/home-data-migration/src/main/resources/db/changelog/0.0.1/Issue426.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet id="Issue426.001" author="vladyslavyarets">
+        <dropForeignKeyConstraint baseTableName="result_question_variants" constraintName="result_question_fk"/>
+        <dropForeignKeyConstraint baseTableName="result_question_variants" constraintName="answer_variant_fk"/>
+        <dropTable tableName="result_question_variants" cascadeConstraints="true"/>
+    </changeSet>
+
+    <changeSet id="Issue426.002" author="vladyslavyarets">
+        <dropForeignKeyConstraint baseTableName="question_votes" constraintName="vote_fk"/>
+        <dropForeignKeyConstraint baseTableName="question_votes" constraintName="question_fk"/>
+        <dropTable tableName="question_votes" cascadeConstraints="true"/>
+    </changeSet>
+
+    <changeSet id="Issue426.003" author="vladyslavyarets">
+        <dropForeignKeyConstraint baseTableName="vote_question_variants" constraintName="answer_variant_fk"/>
+        <dropTable tableName="vote_question_variants" cascadeConstraints="true"/>
+    </changeSet>
+
+    <changeSet id="Issue426.004" author="vladyslavyarets">
+        <dropForeignKeyConstraint baseTableName="result_questions" constraintName="question_fk"/>
+        <dropColumn tableName="result_questions" columnName="question_id"/>
+        <dropColumn tableName="result_questions" columnName="type"/>
+        <addNotNullConstraint tableName="result_questions" columnName="answer_variant_id"/>
+        <addNotNullConstraint tableName="result_questions" columnName="poll_id"/>
+        <addNotNullConstraint tableName="result_questions" columnName="percent_votes"/>
+    </changeSet>
+
+    <changeSet id="Issue426.005" author="vladyslavyarets">
+        <addNotNullConstraint tableName="votes" columnName="type"/>
+        <addNotNullConstraint tableName="votes" columnName="question_id"/>
+    </changeSet>
+
+    <changeSet id="Issue426.006" author="vladyslavyarets">
+        <dropColumn tableName="answer_variants" columnName="question_id"/>
+    </changeSet>
+
+    <changeSet id="Issue426.007" author="vladyslavyarets">
+        <dropSequence sequenceName="result_question_variants_sequence"/>
+        <dropSequence sequenceName="question_votes_sequence"/>
+        <dropSequence sequenceName="vote_question_variants_sequence"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/home-data-migration/src/main/resources/db/changelog/0.0.1/Issue426.xml
+++ b/home-data-migration/src/main/resources/db/changelog/0.0.1/Issue426.xml
@@ -41,6 +41,10 @@
     </changeSet>
 
     <changeSet id="Issue426.007" author="vladyslavyarets">
+        <dropColumn tableName="polls" columnName="result"/>
+    </changeSet>
+
+    <changeSet id="Issue426.008" author="vladyslavyarets">
         <dropSequence sequenceName="result_question_variants_sequence"/>
         <dropSequence sequenceName="question_votes_sequence"/>
         <dropSequence sequenceName="vote_question_variants_sequence"/>

--- a/home-data-migration/src/main/resources/db/changelog/0.0.1/_cumulative.xml
+++ b/home-data-migration/src/main/resources/db/changelog/0.0.1/_cumulative.xml
@@ -29,4 +29,5 @@
     <include file="Issue390.xml" relativeToChangelogFile="true"/>
     <include file="Issue404.xml" relativeToChangelogFile="true"/>
     <include file="Issue412.xml" relativeToChangelogFile="true"/>
+    <include file="Issue426.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/Poll.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/Poll.java
@@ -71,6 +71,4 @@ public class Poll extends BaseEntity {
     @OneToMany(mappedBy = "poll", cascade = CascadeType.PERSIST)
     private List<PollQuestion> pollQuestions;
 
-    @Column(name = "result")
-    private String result;
 }

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/results/ResultQuestion.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/results/ResultQuestion.java
@@ -29,11 +29,6 @@ public class ResultQuestion extends BaseEntity {
     @JoinColumn(name = "answer_variant_id")
     private AnswerVariant answerVariant;
 
-    //TODO: this field needs to be removed in task #417
-    @Convert(converter = PollQuestionTypeAttributeConverter.class)
-    @JoinColumn(name = "type")
-    private PollQuestionType type;
-
     @ManyToOne
     @JoinColumn(name = "poll_id")
     private Poll poll;

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/results/ResultQuestion.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/results/ResultQuestion.java
@@ -1,7 +1,6 @@
 package com.softserveinc.ita.homeproject.homedata.poll.results;
 
 import javax.persistence.Column;
-import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -11,8 +10,6 @@ import javax.persistence.Table;
 
 import com.softserveinc.ita.homeproject.homedata.BaseEntity;
 import com.softserveinc.ita.homeproject.homedata.poll.Poll;
-import com.softserveinc.ita.homeproject.homedata.poll.converters.PollQuestionTypeAttributeConverter;
-import com.softserveinc.ita.homeproject.homedata.poll.enums.PollQuestionType;
 import com.softserveinc.ita.homeproject.homedata.poll.question.AnswerVariant;
 import lombok.Getter;
 import lombok.Setter;

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/votes/Vote.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/votes/Vote.java
@@ -8,6 +8,7 @@ import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
@@ -36,7 +37,7 @@ public class Vote extends BaseEntity {
     private User user;
 
     @Convert(converter = PollQuestionTypeAttributeConverter.class)
-    @Column(name = "type", insertable = false, updatable = false)
+    @Column(name = "type", updatable = false)
     private PollQuestionType type;
 
     @Column(name = "advice_answer")

--- a/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/votes/Vote.java
+++ b/home-data/src/main/java/com/softserveinc/ita/homeproject/homedata/poll/votes/Vote.java
@@ -8,7 +8,6 @@ import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/PollServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/PollServiceImpl.java
@@ -362,7 +362,6 @@ public class PollServiceImpl implements PollService {
 
             resultQuestion.setAnswerVariant(entry.getKey());
             resultQuestion.setPoll(poll);
-            resultQuestion.setType(PollQuestionType.MULTIPLE_CHOICE);//TODO:needs to be removed in task #417
             resultQuestion.setVoteCount(entry.getValue().size());
             resultQuestion.setPercentVotes(String.valueOf(
                 votedArea.get()
@@ -388,7 +387,6 @@ public class PollServiceImpl implements PollService {
         for (Map.Entry<AnswerVariant, List<Vote>> entry : answerVariantsToVotes.entrySet()) {
             ResultQuestion resultQuestion = new ResultQuestion();
             resultQuestion.setAnswerVariant(entry.getKey());
-            resultQuestion.setType(PollQuestionType.MULTIPLE_CHOICE);//TODO:needs to be removed in task #417
             resultQuestion.setPoll(poll);
             resultQuestion.setVoteCount(entry.getValue().size());
             resultQuestion.setPercentVotes(String.valueOf(

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/PollServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/poll/PollServiceImpl.java
@@ -18,7 +18,6 @@ import com.softserveinc.ita.homeproject.homedata.cooperation.house.House;
 import com.softserveinc.ita.homeproject.homedata.cooperation.house.HouseRepository;
 import com.softserveinc.ita.homeproject.homedata.poll.Poll;
 import com.softserveinc.ita.homeproject.homedata.poll.PollRepository;
-import com.softserveinc.ita.homeproject.homedata.poll.enums.PollQuestionType;
 import com.softserveinc.ita.homeproject.homedata.poll.enums.PollStatus;
 import com.softserveinc.ita.homeproject.homedata.poll.enums.PollType;
 import com.softserveinc.ita.homeproject.homedata.poll.question.AnswerVariant;

--- a/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/PollServiceImplTest.java
+++ b/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/PollServiceImplTest.java
@@ -396,7 +396,6 @@ class PollServiceImplTest {
 
         positiveResult.setAnswerVariant(question.getAnswerVariants().get(0));
         positiveResult.setPoll(poll);
-        positiveResult.setType(PollQuestionType.MULTIPLE_CHOICE);
         positiveResult.setVoteCount(answerCount - negativeAnswers);
         positiveResult.setPercentVotes(String.valueOf(
             new BigDecimal(answerCount - negativeAnswers)
@@ -407,7 +406,6 @@ class PollServiceImplTest {
 
         negativeResult.setAnswerVariant(question.getAnswerVariants().get(1));
         negativeResult.setPoll(poll);
-        negativeResult.setType(PollQuestionType.MULTIPLE_CHOICE);
         negativeResult.setVoteCount(negativeAnswers);
         negativeResult.setPercentVotes(String.valueOf(
             new BigDecimal(negativeAnswers)


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/426)

## Summary of issue

After finishind [Task #411](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/411) there needs write changesets to delete useless columns and tables in Database, resolve all depending TODO's

## Summary of change

* Add `Issue426.xml` which contained all changesets
* `ResultQuestion`: removed `type` field
* `PollServiceImplTest`: removed method which set `type` for `ResultQuestion`
* `Vote` entity: fix column `type` (remove "insertable=false") 

## Testing approach

Not required

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
