### PR TITLE
Added CrossOrigin Annotation to prevent rejected anwsers from the OauthServer

### DIFF
--- a/home-oauth-server/src/main/java/com/softserveinc/ita/homeproject/homeoauthserver/controller/OauthController.java
+++ b/home-oauth-server/src/main/java/com/softserveinc/ita/homeproject/homeoauthserver/controller/OauthController.java
@@ -14,9 +14,12 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+
+@CrossOrigin
 @RestController
 @RequestMapping("/api/0/oauth2")
 public class OauthController implements ServerApi {


### PR DESCRIPTION
Added CrossOrigin Annotation to prevent rejected anwers from the OauthServer

dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/439)

## Summary of issue

Configured corss origin 

## Testing approach

Required

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
