### PR TITLE
Issue#377 with setting Id fixed

### DIFF
--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/InvitationApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/InvitationApiImpl.java
@@ -66,14 +66,12 @@ public class InvitationApiImpl extends CommonApi implements InvitationsApi {
     public Response createInvitation(CreateInvitation createInvitation) {
         if (createInvitation.getType().equals(InvitationType.APARTMENT)) {
             ApartmentInvitationDto invitationDto = mapper.convert(createInvitation, ApartmentInvitationDto.class);
-
             ApartmentInvitationDto invitation = apartmentInvitationService.createInvitation(invitationDto);
             ReadApartmentInvitation readInvitation = mapper.convert(invitation, ReadApartmentInvitation.class);
             readInvitation.setType(InvitationType.APARTMENT);
             return Response.status(Response.Status.CREATED).entity(readInvitation).build();
         } else if (createInvitation.getType().equals(InvitationType.COOPERATION)) {
             CooperationInvitationDto invitationDto = mapper.convert(createInvitation, CooperationInvitationDto.class);
-
             CooperationInvitationDto invitation = cooperationInvitationService.createInvitation(invitationDto);
             ReadCooperationInvitation readInvitation = mapper.convert(invitation, ReadCooperationInvitation.class);
             readInvitation.setType(InvitationType.COOPERATION);
@@ -89,7 +87,6 @@ public class InvitationApiImpl extends CommonApi implements InvitationsApi {
         invitationService.deactivateInvitation(invitationId);
         return Response.status(Response.Status.NO_CONTENT).build();
     }
-
 
     @PreAuthorize(MANAGE_IN_COOPERATION)
     @Override

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/InvitationApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/InvitationApiImpl.java
@@ -67,18 +67,12 @@ public class InvitationApiImpl extends CommonApi implements InvitationsApi {
         if (createInvitation.getType().equals(InvitationType.APARTMENT)) {
             ApartmentInvitationDto invitationDto = mapper.convert(createInvitation, ApartmentInvitationDto.class);
 
-            //TODO FIX IN ISSUE #377
-            invitationDto.setId(null);
-
             ApartmentInvitationDto invitation = apartmentInvitationService.createInvitation(invitationDto);
             ReadApartmentInvitation readInvitation = mapper.convert(invitation, ReadApartmentInvitation.class);
             readInvitation.setType(InvitationType.APARTMENT);
             return Response.status(Response.Status.CREATED).entity(readInvitation).build();
         } else if (createInvitation.getType().equals(InvitationType.COOPERATION)) {
             CooperationInvitationDto invitationDto = mapper.convert(createInvitation, CooperationInvitationDto.class);
-
-            //TODO FIX IN ISSUE #377
-            invitationDto.setId(null);
 
             CooperationInvitationDto invitation = cooperationInvitationService.createInvitation(invitationDto);
             ReadCooperationInvitation readInvitation = mapper.convert(invitation, ReadCooperationInvitation.class);

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/mapper/config/impl/ApartmentInvitationDTOMappingConfig.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/mapper/config/impl/ApartmentInvitationDTOMappingConfig.java
@@ -3,14 +3,10 @@ package com.softserveinc.ita.homeproject.application.mapper.config.impl;
 import com.softserveinc.ita.homeproject.application.mapper.config.HomeMappingConfig;
 import com.softserveinc.ita.homeproject.application.model.CreateApartmentInvitation;
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.apartment.ApartmentInvitationDto;
-import lombok.RequiredArgsConstructor;
 import org.modelmapper.TypeMap;
 import org.springframework.stereotype.Component;
 
-
-
 @Component
-@RequiredArgsConstructor
 public class ApartmentInvitationDTOMappingConfig
     implements HomeMappingConfig<CreateApartmentInvitation, ApartmentInvitationDto> {
 

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/mapper/config/impl/ApartmentInvitationDTOMappingConfig.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/mapper/config/impl/ApartmentInvitationDTOMappingConfig.java
@@ -1,0 +1,21 @@
+package com.softserveinc.ita.homeproject.application.mapper.config.impl;
+
+import com.softserveinc.ita.homeproject.application.mapper.config.HomeMappingConfig;
+import com.softserveinc.ita.homeproject.application.model.CreateApartmentInvitation;
+import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.apartment.ApartmentInvitationDto;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.TypeMap;
+import org.springframework.stereotype.Component;
+
+
+
+@Component
+@RequiredArgsConstructor
+public class ApartmentInvitationDTOMappingConfig
+    implements HomeMappingConfig<CreateApartmentInvitation, ApartmentInvitationDto> {
+
+    @Override
+    public void addMappings(TypeMap<CreateApartmentInvitation, ApartmentInvitationDto> typeMap) {
+        typeMap.addMappings(mp -> mp.skip(ApartmentInvitationDto::setId));
+    }
+}

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/mapper/config/impl/CooperationInvitationDTOMappingConfig.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/mapper/config/impl/CooperationInvitationDTOMappingConfig.java
@@ -1,0 +1,18 @@
+package com.softserveinc.ita.homeproject.application.mapper.config.impl;
+
+import com.softserveinc.ita.homeproject.application.mapper.config.HomeMappingConfig;
+import com.softserveinc.ita.homeproject.application.model.CreateCooperationInvitation;
+import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.cooperation.CooperationInvitationDto;
+import org.modelmapper.TypeMap;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class CooperationInvitationDTOMappingConfig
+    implements HomeMappingConfig<CreateCooperationInvitation, CooperationInvitationDto> {
+
+    @Override
+    public void addMappings(TypeMap<CreateCooperationInvitation, CooperationInvitationDto> typeMap) {
+        typeMap.addMappings(mp -> mp.skip(CooperationInvitationDto::setId));
+    }
+}

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/mapper/config/impl/CooperationInvitationDTOMappingConfig.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/mapper/config/impl/CooperationInvitationDTOMappingConfig.java
@@ -6,7 +6,6 @@ import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.c
 import org.modelmapper.TypeMap;
 import org.springframework.stereotype.Component;
 
-
 @Component
 public class CooperationInvitationDTOMappingConfig
     implements HomeMappingConfig<CreateCooperationInvitation, CooperationInvitationDto> {


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

Problem with converting by ModelMapper. When we try to convert createInvitation instance to ApartmentInvitationDto or CooperationInvitationDto modelMapper sets Apartment ID or Cooperation ID in field ID. (#377 )

## Summary of change

In fact, createInvitation is an instance of CreateApartmentInvitation or CreateCooperationInvitation class. Settings for skipping sets of Ids was added to modelMapper configuration.

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
