### PR TITLE
Change registration link in the invitation letter

### DIFF
--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/email/BaseEmailService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/email/BaseEmailService.java
@@ -27,6 +27,9 @@ public abstract class BaseEmailService<T extends Invitation, D extends Invitatio
     @Autowired
     private UserRepository userRepository;
 
+    private static final String UI_HOST = "https://home-project-ui.herokuapp.com";
+
+
     @SneakyThrows
     public void executeAllInvitationsByType() {
         List<D> invitations = getInvitationService().getAllActiveInvitations();
@@ -50,13 +53,18 @@ public abstract class BaseEmailService<T extends Invitation, D extends Invitatio
 
     protected void checkRegistration(InvitationDto invitationDto, MailDto mailDto) {
         if (userRepository.findByEmail(invitationDto.getEmail()).isEmpty()) {
-            mailDto.setLink("https://home-project-academy.herokuapp.com/api/0/apidocs/index.html#post-/users");
+            mailDto.setLink(getRegistrationUrl(mailDto));
             mailDto.setIsRegistered(false);
         } else {
             mailDto.setLink(
                 "https://home-project-academy.herokuapp.com/api/0/apidocs/index.html#post-/invitations/invitation-approval");
             mailDto.setIsRegistered(true);
         }
+    }
+
+    protected String getRegistrationUrl(MailDto mailDto) {
+        return UI_HOST + String.format("/register-user?email=%s&token=%s", mailDto.getEmail(),
+            mailDto.getRegistrationToken());
     }
 
     protected abstract InvitationService<T, D> getInvitationService();


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/444)

## Summary of issue

Due to UI was deployed to heroku (https://home-project-ui.herokuapp.com/), the registration link needs to be changed to bring the user to the UI registration window (/register-user) instead of SwaggerUI. The registration link should contain the email address and token of the user who will be registering as a URL variables.

## Summary of change

Changed link generation in ```BaseMailService.java```

## Testing approach

Not required

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
