### PR TITLE
Refactore mail service implementation

### DIFF
--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/mail/mock/MailUtil.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/mail/mock/MailUtil.java
@@ -44,7 +44,7 @@ public class MailUtil {
 
     @SneakyThrows
     private static <T> T waitFor(Supplier<T> supplier) {
-        int timeout = 5000;
+        int timeout = 15000;
         int pauseTime = 200;
         int n = timeout / pauseTime;
         T result = null;

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/cooperation/invitation/InvitationDto.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/dto/cooperation/invitation/InvitationDto.java
@@ -4,12 +4,13 @@ import com.softserveinc.ita.homeproject.homedata.general.address.Address;
 import com.softserveinc.ita.homeproject.homeservice.dto.BaseDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.enums.InvitationStatusDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.enums.InvitationTypeDto;
+import com.softserveinc.ita.homeproject.homeservice.service.general.email.Mailable;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-public abstract class InvitationDto extends BaseDto {
+public abstract class InvitationDto extends Mailable {
 
     private InvitationStatusDto status;
 

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/invitation/InvitationService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/invitation/InvitationService.java
@@ -1,20 +1,17 @@
 package com.softserveinc.ita.homeproject.homeservice.service.cooperation.invitation;
 
-import java.util.List;
-
 import com.softserveinc.ita.homeproject.homedata.cooperation.invitation.Invitation;
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.InvitationDto;
 import com.softserveinc.ita.homeproject.homeservice.service.QueryableService;
+import com.softserveinc.ita.homeproject.homeservice.service.general.email.MailableService;
 
-public interface InvitationService<T extends Invitation, D extends InvitationDto> extends QueryableService<T, D> {
+
+public interface InvitationService<T extends Invitation, D extends InvitationDto> extends QueryableService<T, D>,
+    MailableService {
 
     D createInvitation(D invitationDto);
 
-    List<D> getAllActiveInvitations();
-
     void markInvitationsAsOverdue();
-
-    void updateSentDateTimeAndStatus(Long id);
 
     void deactivateInvitation(Long id);
 
@@ -23,5 +20,4 @@ public interface InvitationService<T extends Invitation, D extends InvitationDto
     void registerWithRegistrationToken(String token);
 
     InvitationDto findInvitationByRegistrationToken(String token);
-
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/invitation/InvitationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/invitation/InvitationServiceImpl.java
@@ -32,8 +32,6 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 
-
-
 @Service
 @RequiredArgsConstructor
 @Primary
@@ -60,7 +58,7 @@ public class InvitationServiceImpl implements InvitationService<Invitation, Invi
     }
 
     @Override
-    public List<InvitationDto> getAllActiveInvitations() {
+    public List<InvitationDto> getAllUnsentLetters() {
         List<Invitation> allNotSentInvitations = invitationRepository
                 .findAllBySentDatetimeIsNullAndStatusEqualsAndEnabledEquals(
                         InvitationStatus.PENDING, true);
@@ -91,7 +89,6 @@ public class InvitationServiceImpl implements InvitationService<Invitation, Invi
         invitation.setSentDatetime(LocalDateTime.now());
         invitationRepository.save(invitation);
     }
-
 
     private Invitation findInvitationById(Long id) {
         return invitationRepository.findById(id).orElseThrow(() ->
@@ -131,7 +128,6 @@ public class InvitationServiceImpl implements InvitationService<Invitation, Invi
         anyInvitation.setEnabled(false);
         invitationRepository.save(anyInvitation);
     }
-
 
     @Override
     public InvitationDto findInvitationByRegistrationToken(String token) {

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/invitation/apartment/ApartmentInvitationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/invitation/apartment/ApartmentInvitationServiceImpl.java
@@ -130,7 +130,7 @@ public class ApartmentInvitationServiceImpl implements InvitationService<Apartme
     }
 
     @Override
-    public List<ApartmentInvitationDto> getAllActiveInvitations() {
+    public List<ApartmentInvitationDto> getAllUnsentLetters() {
         List<ApartmentInvitation> allNotSentInvitations = apartmentInvitationRepository
             .findAllBySentDatetimeIsNullAndEnabledEqualsAndStatusEqualsAndTypeEquals(true,
                 InvitationStatus.PENDING, InvitationType.APARTMENT);

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/invitation/cooperation/CooperationInvitationServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/cooperation/invitation/cooperation/CooperationInvitationServiceImpl.java
@@ -142,7 +142,7 @@ public class CooperationInvitationServiceImpl
     }
 
     @Override
-    public List<CooperationInvitationDto> getAllActiveInvitations() {
+    public List<CooperationInvitationDto> getAllUnsentLetters() {
         List<CooperationInvitation> allNotSentInvitations = cooperationInvitationRepository
             .findAllBySentDatetimeIsNullAndStatusEqualsAndEnabledEqualsAndTypeEquals(
                 InvitationStatus.PENDING, true, InvitationType.COOPERATION);

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/email/Mailable.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/email/Mailable.java
@@ -1,0 +1,11 @@
+package com.softserveinc.ita.homeproject.homeservice.service.general.email;
+
+import com.softserveinc.ita.homeproject.homeservice.dto.BaseDto;
+
+
+public abstract class Mailable extends BaseDto {
+
+    public abstract String getEmail();
+
+    public abstract String getRegistrationToken();
+}

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/email/MailableService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/email/MailableService.java
@@ -1,0 +1,10 @@
+package com.softserveinc.ita.homeproject.homeservice.service.general.email;
+
+import java.util.List;
+
+
+public interface MailableService {
+    List<? extends Mailable> getAllUnsentLetters();
+
+    void updateSentDateTimeAndStatus(Long id);
+}

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/email/SendApartmentEmailService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/email/SendApartmentEmailService.java
@@ -3,7 +3,6 @@ package com.softserveinc.ita.homeproject.homeservice.service.general.email;
 import java.math.BigDecimal;
 
 import com.softserveinc.ita.homeproject.homedata.cooperation.invitation.apartment.ApartmentInvitation;
-import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.InvitationDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.apartment.ApartmentInvitationDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.enums.InvitationTypeDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.general.mail.MailDto;
@@ -11,9 +10,9 @@ import com.softserveinc.ita.homeproject.homeservice.service.cooperation.invitati
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-@Component
 
-public class SendApartmentEmailService extends BaseEmailService<ApartmentInvitation, ApartmentInvitationDto> {
+@Component
+public class SendApartmentEmailService extends BaseEmailService {
 
     private final InvitationService<ApartmentInvitation, ApartmentInvitationDto> invitationService;
 
@@ -24,8 +23,8 @@ public class SendApartmentEmailService extends BaseEmailService<ApartmentInvitat
     }
 
     @Override
-    protected MailDto createBaseMailDto(InvitationDto invitationDto) {
-        ApartmentInvitationDto invitation = mapper.convert(invitationDto, ApartmentInvitationDto.class);
+    protected MailDto createBaseMailDto(Mailable letter) {
+        ApartmentInvitationDto invitation = mapper.convert(letter, ApartmentInvitationDto.class);
         MailDto mailDto = new MailDto();
         mailDto.setType(InvitationTypeDto.APARTMENT);
         mailDto.setApartmentNumber(invitation.getApartmentNumber());
@@ -34,7 +33,7 @@ public class SendApartmentEmailService extends BaseEmailService<ApartmentInvitat
     }
 
     @Override
-    protected InvitationService<ApartmentInvitation, ApartmentInvitationDto> getInvitationService() {
+    protected InvitationService<ApartmentInvitation, ApartmentInvitationDto> getMailableService() {
         return invitationService;
     }
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/email/SendCooperationEmailService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/email/SendCooperationEmailService.java
@@ -3,7 +3,6 @@ package com.softserveinc.ita.homeproject.homeservice.service.general.email;
 import com.softserveinc.ita.homeproject.homedata.cooperation.Cooperation;
 import com.softserveinc.ita.homeproject.homedata.cooperation.CooperationRepository;
 import com.softserveinc.ita.homeproject.homedata.cooperation.invitation.cooperation.CooperationInvitation;
-import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.InvitationDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.cooperation.CooperationInvitationDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.enums.InvitationTypeDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.general.mail.MailDto;
@@ -12,15 +11,13 @@ import com.softserveinc.ita.homeproject.homeservice.service.cooperation.invitati
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-@Component
 
-public class SendCooperationEmailService extends BaseEmailService<CooperationInvitation, CooperationInvitationDto> {
+@Component
+public class SendCooperationEmailService extends BaseEmailService {
 
     private static final String NOT_FOUND_COOPERATION_FORMAT = "Can't find cooperation with given ID: %d";
 
     private final InvitationService<CooperationInvitation, CooperationInvitationDto> invitationService;
-
-    private final CooperationRepository cooperationRepository;
 
     public SendCooperationEmailService(
         @Qualifier(value = "cooperationInvitationServiceImpl")
@@ -31,13 +28,12 @@ public class SendCooperationEmailService extends BaseEmailService<CooperationInv
     }
 
     @Override
-    protected MailDto createBaseMailDto(InvitationDto invitationDto) {
-        CooperationInvitationDto invitation = mapper.convert(invitationDto, CooperationInvitationDto.class);
+    protected MailDto createBaseMailDto(Mailable letter) {
+        CooperationInvitationDto invitation = mapper.convert(letter, CooperationInvitationDto.class);
         Cooperation coop = cooperationRepository.findById(invitation.getCooperationId())
             .filter(Cooperation::getEnabled)
             .orElseThrow(() -> new NotFoundHomeException(
                 String.format(NOT_FOUND_COOPERATION_FORMAT, invitation.getCooperationId())));
-
         MailDto mailDto = new MailDto();
         mailDto.setRole(invitation.getRole().getName());
         mailDto.setCooperationName(coop.getName());
@@ -45,9 +41,8 @@ public class SendCooperationEmailService extends BaseEmailService<CooperationInv
         return mailDto;
     }
 
-
     @Override
-    protected InvitationService<CooperationInvitation, CooperationInvitationDto> getInvitationService() {
+    protected InvitationService<CooperationInvitation, CooperationInvitationDto> getMailableService() {
         return invitationService;
     }
 }

--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/mail/InvitationMailServiceImpl.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/mail/InvitationMailServiceImpl.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class MailServiceImpl implements MailService {
+public class InvitationMailServiceImpl implements MailService {
 
     private final JavaMailSender mailSender;
 

--- a/home-service/src/main/resources/application-home-service.properties
+++ b/home-service/src/main/resources/application-home-service.properties
@@ -6,6 +6,8 @@ spring.mail.password=${MAIL_PASSWORD:wubtugptvtkmehxn}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
+home.project.ui.host=https://home-project-ui.herokuapp.com
+
 #Quartz service
 spring.quartz.job-store-type = jdbc
 spring.quartz.properties.org.quartz.jobStore.class=org.quartz.impl.jdbcjobstore.JobStoreCMT

--- a/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/InvitationMailServiceImplTest.java
+++ b/home-service/src/test/java/com/softserveinc/ita/homeproject/homeservice/service/impl/InvitationMailServiceImplTest.java
@@ -8,7 +8,7 @@ import javax.mail.internet.MimeMessage;
 
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.invitation.enums.InvitationTypeDto;
 import com.softserveinc.ita.homeproject.homeservice.dto.general.mail.MailDto;
-import com.softserveinc.ita.homeproject.homeservice.service.general.mail.MailServiceImpl;
+import com.softserveinc.ita.homeproject.homeservice.service.general.mail.InvitationMailServiceImpl;
 import com.softserveinc.ita.homeproject.homeservice.service.poll.template.TemplateService;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,11 +22,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 
 @ExtendWith(SpringExtension.class)
-class MailServiceImplTest {
+class InvitationMailServiceImplTest {
     private static MailDto mailDto;
 
     @InjectMocks
-    private MailServiceImpl mailService;
+    private InvitationMailServiceImpl mailService;
 
     @Mock
     private MimeMessage mimeMessage;


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/450)


## Summary of issue

Currently we have BaseEmailService which works with Invitation only. Refactor this functionality so we can send any entity which contains following fields: id, email, content.

## Summary of change

- 2 methods from```InvitationService``` interface was segregated into the new ```MailableService```
- Add new ```Mailable``` abstract class.
- Refactor ```BaseEmailService``` to improve scalability
- Segregate variable value of UI host into ```.properties``` file

## Testing approach

Not required

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
