### PR TITLE
change getRegistrationUrl() in BaseEmailService

### DIFF
--- a/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/email/BaseEmailService.java
+++ b/home-service/src/main/java/com/softserveinc/ita/homeproject/homeservice/service/general/email/BaseEmailService.java
@@ -51,17 +51,17 @@ public abstract class BaseEmailService {
 
     protected void checkRegistration(Mailable letter, MailDto mailDto) {
         if (userRepository.findByEmail(letter.getEmail()).isEmpty()) {
-            mailDto.setLink(getRegistrationUrl(mailDto));
+            mailDto.setLink(getRegistrationUrl(mailDto, "register-user"));
             mailDto.setIsRegistered(false);
         } else {
             mailDto.setLink(
-                "https://home-project-academy.herokuapp.com/api/0/apidocs/index.html#post-/invitations/invitation-approval");
+                    getRegistrationUrl(mailDto, "register-cooperation"));
             mailDto.setIsRegistered(true);
         }
     }
 
-    protected String getRegistrationUrl(MailDto mailDto) {
-        return uiHost + String.format("/register-user?email=%s&token=%s", mailDto.getEmail(),
+    protected String getRegistrationUrl(MailDto mailDto, String endpoint) {
+        return uiHost + String.format("/%s?email=%s&token=%s", endpoint, mailDto.getEmail(),
             mailDto.getRegistrationToken());
     }
 


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/463)

## Summary of issue

Registration link in the invitation is still pointing to Swagger

## Summary of change

change getRegistrationUrl() in BaseEmailService

## Testing approach

not required

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
