### PR TITLE
add testcase for weak password validation

### DIFF
--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/UserApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/UserApiIT.java
@@ -62,6 +62,23 @@ class UserApiIT {
     }
 
     @Test
+    @SneakyThrows
+    void createNewUserWithWeakPassword() {
+        ReadUser savedUser = createBaseUserForTests();
+        CreateUser createdUser = new CreateUser()
+                .firstName("firstName")
+                .middleName("middleName")
+                .lastName("lastName")
+                .password("123456789")
+                .email("test.receive.apartment@gmail.com");
+
+        assertThatExceptionOfType(ApiException.class)
+                .isThrownBy(() -> userApi.createUserWithHttpInfo(createdUser))
+                .matches(e -> e.getCode() == BAD_REQUEST)
+                .withMessageContaining("Parameter `password` is invalid - must meet the rule");
+    }
+
+    @Test
     void updateUserTest() throws ApiException {
         ReadUser savedUser = createBaseUserForTests();
         UpdateUser updateUser = new UpdateUser()
@@ -474,7 +491,7 @@ class UserApiIT {
     }
 
     @SneakyThrows
-    private ReadUser createNotMatchingUser()  {
+    private ReadUser createNotMatchingUser() {
         CreateCooperation coop = createBaseCooperation();
         cooperationApi.createCooperation(coop);
         String email = coop.getAdminEmail();


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/472)

## Summary of issue

Currently this functionality covered by integration tests but have but there is some bug (wrong HTTP status code and exception message sends from controller in exception path).
Expected behavior: When password is weak the following json should be sended by the application:
 ```
{
  "response_code": 406,
  "error_message": "Password too weak"
}
```

Actual behavior:
```
{
  "response_code": 500,
  "error_message": "Unknown error. Please contact support."
}
```
This functionality will be hotfixed it task #[451](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/451),
but it still needed to be covered with Api tests.

Cover this and relative aspects with api testing

## Summary of change

- Add testcase for weak password validation

## Testing approach

not required

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
