### PR TITLE
Refactor api specification for registration

### DIFF
--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartments/ApartmentApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartments/ApartmentApiIT.java
@@ -22,6 +22,7 @@ import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.CreateApartment;
 import com.softserveinc.ita.homeproject.client.model.CreateApartmentInvitation;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateHouse;
 import com.softserveinc.ita.homeproject.client.model.CreateInvitation;
 import com.softserveinc.ita.homeproject.client.model.InvitationType;
@@ -259,7 +260,7 @@ class ApartmentApiIT {
                 .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
                 .usreo(RandomStringUtils.randomNumeric(8))
                 .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-                .adminEmail("test.receive.messages@gmail.com")
+                .adminData(new CreateCooperationAdminData().email("test.receive.messages@gmail.com"))
                 .address(createAddress());
     }
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartments/QueryApartmentIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartments/QueryApartmentIT.java
@@ -24,6 +24,7 @@ import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.CreateApartment;
 import com.softserveinc.ita.homeproject.client.model.CreateApartmentInvitation;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateHouse;
 import com.softserveinc.ita.homeproject.client.model.CreateInvitation;
 import com.softserveinc.ita.homeproject.client.model.InvitationType;
@@ -222,7 +223,7 @@ class QueryApartmentIT {
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
             .address(createAddress())
-            .adminEmail("test.receive.messages@gmail.com");
+            .adminData(new CreateCooperationAdminData().email("test.receive.messages@gmail.com"));
     }
 
     private Address createAddress() {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/ContactApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/ContactApiIT.java
@@ -23,6 +23,7 @@ import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.ContactType;
 import com.softserveinc.ita.homeproject.client.model.CreateContact;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateEmailContact;
 import com.softserveinc.ita.homeproject.client.model.CreatePhoneContact;
 import com.softserveinc.ita.homeproject.client.model.CreateUser;
@@ -504,7 +505,8 @@ class ContactApiIT {
                 .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
                 .usreo(RandomStringUtils.randomNumeric(8))
                 .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-                .adminEmail(RandomStringUtils.randomAlphabetic(12).concat("@gmail.com"))
+                .adminData(new CreateCooperationAdminData()
+                    .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com")))
                 .address(createAddress())
                 .contacts(createContactList());
     }

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/ContactApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/ContactApiIT.java
@@ -511,9 +511,6 @@ class ContactApiIT {
 
     private CreateUser createBaseUser() {
         return new CreateUser()
-                .firstName("firstName")
-                .middleName("middleName")
-                .lastName("lastName")
                 .password(ApiClientUtil.VALID_USER_PASSWORD)
                 .email("test.receive.apartment@gmail.com");
     }
@@ -526,16 +523,6 @@ class ContactApiIT {
                 .region("Dnipro")
                 .street("street")
                 .zipCode("zipCode");
-    }
-
-    private CreateUser createTestUser() {
-        return new CreateUser()
-                .firstName("firstName")
-                .middleName("middleName")
-                .lastName("lastName")
-                .password(ApiClientUtil.VALID_USER_PASSWORD)
-                .email(RandomStringUtils.randomAlphabetic(5).concat("@example.com"))
-                .contacts(createContactList());
     }
 
     private void assertEmailContact(CreateContact expected, ReadContact actual) {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/QueryContactIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/QueryContactIT.java
@@ -17,6 +17,7 @@ import com.softserveinc.ita.homeproject.client.ApiException;
 import com.softserveinc.ita.homeproject.client.api.ContactApi;
 import com.softserveinc.ita.homeproject.client.api.CooperationApi;
 import com.softserveinc.ita.homeproject.client.api.UserApi;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.ReadContact;
 import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.ContactType;
@@ -306,7 +307,8 @@ class QueryContactIT {
                 .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
                 .usreo(RandomStringUtils.randomNumeric(8))
                 .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-                .adminEmail(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"))
+                .adminData(new CreateCooperationAdminData()
+                    .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com")))
                 .address(createAddress());
     }
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/QueryContactIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/contacts/QueryContactIT.java
@@ -301,16 +301,6 @@ class QueryContactIT {
         return createContactList;
     }
 
-    private CreateUser createTestUser() {
-        return new CreateUser()
-                .firstName("firstName")
-                .middleName("middleName")
-                .lastName("lastName")
-                .password(ApiClientUtil.VALID_USER_PASSWORD)
-                .email(RandomStringUtils.randomAlphabetic(5).concat("@example.com"))
-                .contacts(createContactList());
-    }
-
     private CreateCooperation createBaseCooperation() {
         return new CreateCooperation()
                 .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
@@ -322,12 +312,9 @@ class QueryContactIT {
 
     private CreateUser createBaseUser() {
         return new CreateUser()
-                .firstName("firstName")
-                .middleName("middleName")
-                .lastName("lastName")
                 .password(ApiClientUtil.VALID_USER_PASSWORD)
                 .email("test.receive.apartment@gmail.com")
-                .contacts(createContactList());
+                .phoneNumber("380501112233");
     }
 
     private Address createAddress() {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/CooperationApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/CooperationApiIT.java
@@ -89,7 +89,7 @@ class CooperationApiIT {
             .name("Cooperation Cooperation Cooperation Cooperation Cooperation Cooperation Cooperation")
             .usreo("25252525")
             .iban("UA250820210147250819980000000")
-            .adminEmail("test.receive.messages@gmail.com")
+            .adminData(new CreateCooperationAdminData().email("test.receive.messages@gmail.com"))
             .address(createAddress())
             .houses(createHouseList());
 
@@ -105,7 +105,7 @@ class CooperationApiIT {
             .name("name")
             .usreo("123456789101112131415")
             .iban("UA250820210147250819980000000")
-            .adminEmail("test.receive.messages@gmail.com")
+            .adminData(new CreateCooperationAdminData().email("test.receive.messages@gmail.com"))
             .address(createAddress())
             .houses(createHouseList());
 
@@ -121,7 +121,7 @@ class CooperationApiIT {
             .name("name")
             .usreo("25252525")
             .iban("12345678910111213141516171819202122232425")
-            .adminEmail("test.receive.messages@gmail.com")
+            .adminData(new CreateCooperationAdminData().email("test.receive.messages@gmail.com"))
             .address(createAddress())
             .houses(createHouseList());
 
@@ -140,7 +140,7 @@ class CooperationApiIT {
             .name("name")
             .usreo("26573474")
             .iban(createCoop.getIban())
-            .adminEmail("test.receive.messages@gmail.com")
+            .adminData(new CreateCooperationAdminData().email("test.receive.messages@gmail.com"))
             .address(createAddress())
             .houses(createHouseList());
 
@@ -157,7 +157,7 @@ class CooperationApiIT {
             .name("name")
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail("test.receive.messages@gmail.com")
+            .adminData(new CreateCooperationAdminData().email("test.receive.messages@gmail.com"))
             .address(createAddressWithNull());
 
         assertThatExceptionOfType(ApiException.class)
@@ -171,7 +171,7 @@ class CooperationApiIT {
             .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail("test.receive.messages@gmail.com")
+            .adminData(new CreateCooperationAdminData().email("test.receive.messages@gmail.com"))
             .address(createAddress())
             .houses(createHouseList())
             .contacts(createContactList());

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/QueryCooperationIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/QueryCooperationIT.java
@@ -6,6 +6,7 @@ import com.softserveinc.ita.homeproject.client.ApiException;
 import com.softserveinc.ita.homeproject.client.api.CooperationApi;
 import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.ReadCooperation;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
@@ -197,7 +198,7 @@ class QueryCooperationIT {
             .name(RandomStringUtils.randomAlphabetic(10))
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail("test.receive.messages@gmail.com")
+            .adminData(new CreateCooperationAdminData().email("test.receive.messages@gmail.com"))
             .address(new Address()
                 .city("Dnepr")
                 .district("District")

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/contacts/CooperationContactApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/contacts/CooperationContactApiIT.java
@@ -21,6 +21,7 @@ import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.ContactType;
 import com.softserveinc.ita.homeproject.client.model.CreateContact;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateEmailContact;
 import com.softserveinc.ita.homeproject.client.model.CreateHouse;
 import com.softserveinc.ita.homeproject.client.model.CreatePhoneContact;
@@ -355,7 +356,7 @@ class CooperationContactApiIT {
             .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail("test.receive.messages@gmail.com")
+            .adminData(new CreateCooperationAdminData().email("test.receive.messages@gmail.com"))
             .address(createAddress())
             .houses(createHouseList())
             .contacts(createContactList());

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/contacts/QueryCoopContactIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/cooperations/contacts/QueryCoopContactIT.java
@@ -21,6 +21,7 @@ import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.ContactType;
 import com.softserveinc.ita.homeproject.client.model.CreateContact;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateEmailContact;
 import com.softserveinc.ita.homeproject.client.model.CreateHouse;
 import com.softserveinc.ita.homeproject.client.model.CreatePhoneContact;
@@ -204,7 +205,7 @@ class QueryCoopContactIT {
             .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail("test.receive.messages@gmail.com")
+            .adminData(new CreateCooperationAdminData().email("test.receive.messages@gmail.com"))
             .address(createAddress())
             .houses(createHouseList())
             .contacts(createContactList());

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/houses/HouseApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/houses/HouseApiIT.java
@@ -20,6 +20,7 @@ import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.ContactType;
 import com.softserveinc.ita.homeproject.client.model.CreateContact;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateEmailContact;
 import com.softserveinc.ita.homeproject.client.model.CreateHouse;
 import com.softserveinc.ita.homeproject.client.model.ReadCooperation;
@@ -255,7 +256,7 @@ class HouseApiIT {
             .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail("test.receive.messages@gmail.com")
+            .adminData(new CreateCooperationAdminData().email("test.receive.messages@gmail.com"))
             .address(createAddress())
             .houses(createHouseList())
             .contacts(createContactList());

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/houses/QueryHouseIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/houses/QueryHouseIT.java
@@ -21,6 +21,7 @@ import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.ContactType;
 import com.softserveinc.ita.homeproject.client.model.CreateContact;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateEmailContact;
 import com.softserveinc.ita.homeproject.client.model.CreateHouse;
 import com.softserveinc.ita.homeproject.client.model.ReadCooperation;
@@ -175,7 +176,7 @@ class QueryHouseIT {
             .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail("test.receive.messages@gmail.com")
+            .adminData(new CreateCooperationAdminData().email("test.receive.messages@gmail.com"))
             .address(createAddress())
             .houses(createHouseList())
             .contacts(createContactList());

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/InvitationApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/InvitationApiIT.java
@@ -26,6 +26,7 @@ import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.CreateApartment;
 import com.softserveinc.ita.homeproject.client.model.CreateApartmentInvitation;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperationInvitation;
 import com.softserveinc.ita.homeproject.client.model.CreateHouse;
 import com.softserveinc.ita.homeproject.client.model.CreateInvitation;
@@ -63,7 +64,7 @@ class InvitationApiIT {
     void isEmailSentTest() throws Exception {
         CreateCooperation createCoop = createCooperation();
         cooperationApi.createCooperationWithHttpInfo(createCoop);
-        MailUtil.waitLetterForEmail(createCoop.getAdminEmail());
+        MailUtil.waitLetterForEmail(createCoop.getAdminData().getEmail());
     }
 
     @Test
@@ -311,7 +312,7 @@ class InvitationApiIT {
                 .name(RandomStringUtils.randomAlphabetic(10).concat(" Cooperation"))
                 .usreo(RandomStringUtils.randomNumeric(8))
                 .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-                .adminEmail(email)
+                .adminData(new CreateCooperationAdminData().email(email))
                 .address(createAddress());
     }
 
@@ -320,7 +321,7 @@ class InvitationApiIT {
                 .name(RandomStringUtils.randomAlphabetic(10).concat(" Cooperation"))
                 .usreo(RandomStringUtils.randomNumeric(8))
                 .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-                .adminEmail(createBaseUser().getEmail())
+                .adminData(new CreateCooperationAdminData().email(createBaseUser().getEmail()))
                 .address(createAddress());
     }
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/InvitationApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/InvitationApiIT.java
@@ -302,9 +302,6 @@ class InvitationApiIT {
 
     private CreateUser createBaseUser() {
         return new CreateUser()
-                .firstName("firstName")
-                .middleName("middleName")
-                .lastName("lastName")
                 .password(ApiClientUtil.VALID_USER_PASSWORD)
                 .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"));
     }

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/QueryInvitationIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/QueryInvitationIT.java
@@ -22,6 +22,7 @@ import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.CreateApartment;
 import com.softserveinc.ita.homeproject.client.model.CreateApartmentInvitation;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateHouse;
 import com.softserveinc.ita.homeproject.client.model.CreateInvitation;
 import com.softserveinc.ita.homeproject.client.model.InvitationStatus;
@@ -237,7 +238,8 @@ public class QueryInvitationIT {
             .name("newCooperationTest")
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"))
+            .adminData(new CreateCooperationAdminData()
+                .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com")))
             .address(createAddress());
     }
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/ownerships/OwnershipApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/ownerships/OwnershipApiIT.java
@@ -242,7 +242,8 @@ class OwnershipApiIT {
             .name("newCooperationTest")
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"))
+            .adminData(new CreateCooperationAdminData()
+                .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com")))
             .address(createAddress());
     }
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/ownerships/OwnershipApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/ownerships/OwnershipApiIT.java
@@ -69,10 +69,7 @@ class OwnershipApiIT {
         TEST_DELETE_OWNERSHIP_APARTMENT_ID = createdApartment.getId();
 
         List<CreateUser> users = Stream.generate(CreateUser::new).map(x ->
-                x.firstName("firstName")
-                    .middleName("middleName")
-                    .lastName("middleName")
-                    .password(ApiClientUtil.VALID_USER_PASSWORD)
+                x.password(ApiClientUtil.VALID_USER_PASSWORD)
                     .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com")))
             .limit(numInvitations)
             .collect(Collectors.toList());
@@ -236,9 +233,6 @@ class OwnershipApiIT {
 
     private CreateUser createBaseUser() {
         return new CreateUser()
-            .firstName("firstName")
-            .middleName("middleName")
-            .lastName("lastName")
             .password(ApiClientUtil.VALID_USER_PASSWORD)
             .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"));
     }
@@ -300,9 +294,6 @@ class OwnershipApiIT {
 
     private void assertUser(CreateUser expected, ReadUser actual) {
         assertNotNull(expected);
-        assertEquals(expected.getFirstName(), actual.getFirstName());
-        assertEquals(expected.getMiddleName(), actual.getMiddleName());
-        assertEquals(expected.getLastName(), actual.getLastName());
         assertEquals(expected.getEmail(), actual.getEmail());
     }
 }

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/ownerships/QueryOwnershipIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/ownerships/QueryOwnershipIT.java
@@ -59,17 +59,13 @@ class QueryOwnershipIT {
         TEST_APARTMENT_ID = createdApartment.getId();
 
         List<CreateUser> users = Stream.generate(CreateUser::new).map(x ->
-                x.firstName("firstName")
-                    .middleName("middleName")
-                    .lastName("middleName")
-                    .password(ApiClientUtil.VALID_USER_PASSWORD)
+                x.password(ApiClientUtil.VALID_USER_PASSWORD)
                     .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com")))
             .limit(numInvitations)
             .collect(Collectors.toList());
 
         users.forEach(x -> {
-            String email = Objects.requireNonNull(
-                    createApartment.getInvitations().get(createApartment.getInvitations().size() - 1)).getEmail();
+            String email = "mail@mail.com";
             ResponseEmailItem letter = MailUtil.waitLetter(MailUtil.predicate().email(email).subject("apartment"));
             x.setRegistrationToken(MailUtil.getToken(letter));
             x.setEmail(email);
@@ -194,9 +190,6 @@ class QueryOwnershipIT {
 
     private CreateUser createBaseUser() {
         return new CreateUser()
-                .firstName("firstName")
-                .middleName("middleName")
-                .lastName("lastName")
                 .password(ApiClientUtil.VALID_USER_PASSWORD)
                 .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"));
     }

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/ownerships/QueryOwnershipIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/ownerships/QueryOwnershipIT.java
@@ -199,7 +199,8 @@ class QueryOwnershipIT {
                 .name("newCooperationTest")
                 .usreo(RandomStringUtils.randomNumeric(8))
                 .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-                .adminEmail(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"))
+                .adminData(new CreateCooperationAdminData()
+                    .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com")))
                 .address(createAddress());
     }
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/poll_questions/QueryQuestionIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/poll_questions/QueryQuestionIT.java
@@ -22,6 +22,7 @@ import com.softserveinc.ita.homeproject.client.api.PollQuestionApi;
 import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.CreateAdviceQuestion;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateDoubleChoiceQuestion;
 import com.softserveinc.ita.homeproject.client.model.CreateMultipleChoiceQuestion;
 import com.softserveinc.ita.homeproject.client.model.CreatePoll;
@@ -199,7 +200,7 @@ class QueryQuestionIT {
                 .name(RandomStringUtils.randomAlphabetic(12).concat(" Cooperation"))
                 .usreo(RandomStringUtils.randomNumeric(8))
                 .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-                .adminEmail("test.ita.emails@gmail.com")
+                .adminData(new CreateCooperationAdminData().email("test.receive.messages@gmail.com"))
                 .address(createAddress());
     }
 }

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/poll_questions/QuestionApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/poll_questions/QuestionApiIT.java
@@ -21,6 +21,7 @@ import com.softserveinc.ita.homeproject.client.api.PollQuestionApi;
 import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.CreateAdviceQuestion;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateDoubleChoiceQuestion;
 import com.softserveinc.ita.homeproject.client.model.CreateMultipleChoiceQuestion;
 import com.softserveinc.ita.homeproject.client.model.CreatePoll;
@@ -311,7 +312,7 @@ class QuestionApiIT {
                 .name(RandomStringUtils.randomAlphabetic(12).concat(" Cooperation"))
                 .usreo(RandomStringUtils.randomNumeric(8))
                 .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-                .adminEmail("test.ita.emails@gmail.com")
+                .adminData(new CreateCooperationAdminData().email("test.ita.emails@gmail.com"))
                 .address(createAddress());
     }
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/polls/CooperationPollApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/polls/CooperationPollApiIT.java
@@ -22,6 +22,7 @@ import com.softserveinc.ita.homeproject.client.api.PollApi;
 import com.softserveinc.ita.homeproject.client.api.PolledHouseApi;
 import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateHouse;
 import com.softserveinc.ita.homeproject.client.model.CreatePoll;
 import com.softserveinc.ita.homeproject.client.model.HouseLookup;
@@ -172,7 +173,8 @@ class CooperationPollApiIT {
             .name("newCooperationTest")
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"))
+            .adminData(new CreateCooperationAdminData()
+                .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com")))
             .address(createAddress())
             .addHousesItem(createHouse())
             .addHousesItem(createHouse())

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/polls/PollVoteApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/polls/PollVoteApiIT.java
@@ -26,6 +26,7 @@ import com.softserveinc.ita.homeproject.client.model.AnswerVariantLookup;
 import com.softserveinc.ita.homeproject.client.model.CreateAdviceQuestion;
 import com.softserveinc.ita.homeproject.client.model.CreateAdviceQuestionVote;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateMultipleChoiceQuestion;
 import com.softserveinc.ita.homeproject.client.model.CreateMultipleChoiceQuestionVote;
 import com.softserveinc.ita.homeproject.client.model.CreatePoll;
@@ -402,7 +403,8 @@ class PollVoteApiIT {
             .name(String.format("Cooperation #%d for vote test", ++cooperationNumber))
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail(RandomStringUtils.randomAlphabetic(12).concat("@gmail.com"))
+            .adminData(new CreateCooperationAdminData()
+                .email(RandomStringUtils.randomAlphabetic(12).concat("@gmail.com")))
             .address(createAddress());
     }
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/security/LoginIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/security/LoginIT.java
@@ -100,14 +100,10 @@ class LoginIT {
     }
 
     private static CreateUser createBaseUser() {
-
         return new CreateUser()
-            .firstName("firstName")
-            .middleName("middleName")
-            .lastName("lastName")
             .password(ApiClientUtil.VALID_USER_PASSWORD)
             .email(USER_EMAIL)
-            .contacts(createContactList());
+            .phoneNumber("380501112233");
     }
 
     private static List<CreateContact> createContactList() {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/security/LoginIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/security/LoginIT.java
@@ -17,6 +17,7 @@ import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.ContactType;
 import com.softserveinc.ita.homeproject.client.model.CreateContact;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateEmailContact;
 import com.softserveinc.ita.homeproject.client.model.CreatePhoneContact;
 import com.softserveinc.ita.homeproject.client.model.CreateUser;
@@ -151,7 +152,7 @@ class LoginIT {
             .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail(USER_EMAIL)
+            .adminData(new CreateCooperationAdminData().email(USER_EMAIL))
             .address(createAddress());
     }
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/security/PermissionsIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/security/PermissionsIT.java
@@ -30,6 +30,7 @@ import com.softserveinc.ita.homeproject.client.model.CreateApartment;
 import com.softserveinc.ita.homeproject.client.model.CreateApartmentInvitation;
 import com.softserveinc.ita.homeproject.client.model.CreateContact;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateEmailContact;
 import com.softserveinc.ita.homeproject.client.model.CreateHouse;
 import com.softserveinc.ita.homeproject.client.model.CreateInvitation;
@@ -742,7 +743,8 @@ class PermissionsIT {
             .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail(RandomStringUtils.randomAlphabetic(12).concat("@gmail.com"))
+            .adminData(new CreateCooperationAdminData()
+                .email(RandomStringUtils.randomAlphabetic(12).concat("@gmail.com")))
             .address(createAddress())
             .contacts(createContactList());
     }
@@ -752,7 +754,8 @@ class PermissionsIT {
             .name("newCooperationTest")
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail(RandomStringUtils.randomAlphabetic(12).concat("@gmail.com"))
+            .adminData(new CreateCooperationAdminData()
+                .email(RandomStringUtils.randomAlphabetic(12).concat("@gmail.com")))
             .address(createAddress())
             .addHousesItem(createHouse())
             .addHousesItem(createHouse())

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/QueryUserIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/QueryUserIT.java
@@ -17,6 +17,7 @@ import com.softserveinc.ita.homeproject.client.api.CooperationApi;
 import com.softserveinc.ita.homeproject.client.api.UserApi;
 import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateUser;
 import com.softserveinc.ita.homeproject.client.model.ReadUser;
 import lombok.SneakyThrows;
@@ -243,7 +244,8 @@ class QueryUserIT {
                 .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
                 .usreo(RandomStringUtils.randomNumeric(8))
                 .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-                .adminEmail(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"))
+                .adminData(new CreateCooperationAdminData()
+                    .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com")))
                 .address(createAddress());
     }
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/QueryUserIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/QueryUserIT.java
@@ -30,12 +30,6 @@ class QueryUserIT {
 
     private final UserApi userApi = new UserApi(ApiClientUtil.getCooperationAdminClient());
 
-    private final CreateUser expectedUser = new CreateUser()
-            .firstName("Bill")
-            .middleName("Billievich")
-            .lastName("White")
-            .password(ApiClientUtil.VALID_USER_PASSWORD);
-
     @Test
     void getAllUsers() throws ApiException {
         List<ReadUser> expectedListUser = saveListUser();
@@ -223,37 +217,22 @@ class QueryUserIT {
     private List<CreateUser> createUsersList() {
         List<CreateUser> list = new ArrayList<>();
         list.add(new CreateUser().
-                firstName("Alex").
-                middleName("Alexovich").
-                lastName("Young").
                 email(RandomStringUtils.randomAlphabetic(5).concat("@example.com")).
                 password(ApiClientUtil.VALID_USER_PASSWORD)
         );
         list.add(new CreateUser().
-                firstName("Bob").
-                middleName("Bobovich").
-                lastName("Smith").
                 email(RandomStringUtils.randomAlphabetic(5).concat("@example.com")).
                 password(ApiClientUtil.VALID_USER_PASSWORD)
         );
         list.add(new CreateUser().
-                firstName("Jack").
-                middleName("Jackovich").
-                lastName("Gray").
                 email(RandomStringUtils.randomAlphabetic(5).concat("@example.com")).
                 password(ApiClientUtil.VALID_USER_PASSWORD)
         );
         list.add(new CreateUser().
-                firstName("Sindy").
-                middleName("Sindivna").
-                lastName("Black").
                 email(RandomStringUtils.randomAlphabetic(5).concat("@example.com")).
                 password(ApiClientUtil.VALID_USER_PASSWORD)
         );
         list.add(new CreateUser().
-                firstName("Victor").
-                middleName("Viktorovich").
-                lastName("Along").
                 email(RandomStringUtils.randomAlphabetic(5).concat("@example.com")).
                 password(ApiClientUtil.VALID_USER_PASSWORD)
         );
@@ -270,9 +249,6 @@ class QueryUserIT {
 
     private CreateUser createBaseUser() {
         return new CreateUser()
-                .firstName("firstName")
-                .middleName("middleName")
-                .lastName("lastName")
                 .password(ApiClientUtil.VALID_USER_PASSWORD)
                 .email("test.receive.apartment@gmail.com");
     }
@@ -293,13 +269,4 @@ class QueryUserIT {
         CreateUser user = createBaseUser();
         return ApiClientUtil.createCooperationAdmin(cooperationApi, coop, userApi, user);
     }
-
-    private void assertUser(CreateUser expected, ReadUser actual) {
-        assertNotNull(expected);
-        assertEquals(expected.getFirstName(), actual.getFirstName());
-        assertEquals(expected.getMiddleName(), actual.getMiddleName());
-        assertEquals(expected.getLastName(), actual.getLastName());
-        assertEquals(expected.getEmail(), actual.getEmail());
-    }
-
 }

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/ResetPasswordApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/ResetPasswordApiIT.java
@@ -22,6 +22,7 @@ import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.ContactType;
 import com.softserveinc.ita.homeproject.client.model.CreateContact;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateEmailContact;
 import com.softserveinc.ita.homeproject.client.model.CreatePhoneContact;
 import com.softserveinc.ita.homeproject.client.model.CreateUser;
@@ -223,7 +224,8 @@ class ResetPasswordApiIT {
             .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"))
+            .adminData(new CreateCooperationAdminData()
+                .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com")))
             .address(createAddress())
             .contacts(createContactList());
     }

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/ResetPasswordApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/ResetPasswordApiIT.java
@@ -230,9 +230,6 @@ class ResetPasswordApiIT {
 
     private static CreateUser createBaseUser() {
         return new CreateUser()
-            .firstName("firstName")
-            .middleName("middleName")
-            .lastName("lastName")
             .password(ApiClientUtil.VALID_USER_PASSWORD)
             .email("test.receive.apartment@gmail.com");
     }

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/UserApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/UserApiIT.java
@@ -66,9 +66,6 @@ class UserApiIT {
     void createNewUserWithWeakPassword() {
         ReadUser savedUser = createBaseUserForTests();
         CreateUser createdUser = new CreateUser()
-                .firstName("firstName")
-                .middleName("middleName")
-                .lastName("lastName")
                 .password("123456789")
                 .email("test.receive.apartment@gmail.com");
 
@@ -139,10 +136,7 @@ class UserApiIT {
     @Test
     void createUserWithNonExistRegistrationToken() {
         CreateUser createUser = new CreateUser()
-                .firstName("FirstName")
                 .registrationToken(RandomStringUtils.randomAlphabetic(36))
-                .middleName("MiddleName")
-                .lastName("LastName")
                 .password(ApiClientUtil.VALID_USER_PASSWORD)
                 .email("walker@email.com");
 
@@ -155,9 +149,6 @@ class UserApiIT {
     @Test
     void createUserWithRegistrationTokenNull() {
         CreateUser createUser = new CreateUser()
-                .firstName("FirstName")
-                .middleName("MiddleName")
-                .lastName("LastName")
                 .password("somePassword")
                 .email("walker@email.com");
 
@@ -170,9 +161,6 @@ class UserApiIT {
     @Test
     void createUserWithEmptyFirstNameAndMiddleNameAndLastNameTest() {
         CreateUser createUser = new CreateUser()
-                .firstName("")
-                .middleName("")
-                .lastName("")
                 .password("somePassword")
                 .email("walker@email.com");
 
@@ -187,9 +175,6 @@ class UserApiIT {
     @Test
     void createUserWithInvalidFirstNameAndMiddleNameAndLastNameTest() {
         CreateUser createUser = new CreateUser()
-                .firstName("AhmudIbnSalimDeAlpachinoStyleCreatedInAmericaStreet")
-                .middleName("AhmudIbnSalimDeAlpachinoStyleCreatedInAmericaStreet")
-                .lastName("AhmudIbnSalimDeAlpachinoStyleCreatedInAmericaStreet")
                 .password("somePassword")
                 .email("walker@email.com");
 
@@ -204,9 +189,6 @@ class UserApiIT {
     @Test
     void createUserWithEmptyEmailTest() {
         CreateUser createUser = new CreateUser()
-                .firstName("alan")
-                .middleName("alanovich")
-                .lastName("walker")
                 .password("somePassword")
                 .email("");
 
@@ -219,9 +201,6 @@ class UserApiIT {
     @Test
     void createUserInvalidEmailTest() {
         CreateUser createUser = new CreateUser()
-                .firstName("alan")
-                .middleName("alanovich")
-                .lastName("walker")
                 .password("somePassword")
                 .email("email.com");
 
@@ -234,9 +213,6 @@ class UserApiIT {
     @Test
     void createUserWithEmptyPasswordTest() {
         CreateUser createUser = new CreateUser()
-                .firstName("alan")
-                .middleName("alanovich")
-                .lastName("walker")
                 .password("")
                 .email("email@example.com");
 
@@ -249,9 +225,6 @@ class UserApiIT {
     @Test
     void createUserInvalidPasswordTest() {
         CreateUser createUser = new CreateUser()
-                .firstName("alan")
-                .middleName("alanovich")
-                .lastName("walker")
                 .password("some password")
                 .email("email@example.com");
 
@@ -264,9 +237,6 @@ class UserApiIT {
     @Test
     void createUserWithAllNullParametersTest() {
         CreateUser createUser = new CreateUser()
-                .firstName(null)
-                .middleName(null)
-                .lastName(null)
                 .email(null)
                 .password(null);
 
@@ -418,12 +388,9 @@ class UserApiIT {
     private CreateUser createTestUser() {
         return new CreateUser()
                 .registrationToken(RandomStringUtils.randomAlphabetic(36))
-                .firstName("firstName")
-                .middleName("middleName")
-                .lastName("lastName")
                 .password(ApiClientUtil.VALID_USER_PASSWORD)
                 .email(RandomStringUtils.randomAlphabetic(5).concat("@example.com"))
-                .contacts(createContactList());
+                .phoneNumber("380501112233");
     }
 
     private static CreateCooperation createBaseCooperation() {
@@ -438,9 +405,6 @@ class UserApiIT {
 
     private static CreateUser createBaseUser() {
         return new CreateUser()
-                .firstName("firstName")
-                .middleName("middleName")
-                .lastName("lastName")
                 .password(ApiClientUtil.VALID_USER_PASSWORD)
                 .email("test.receive.apartment@gmail.com");
     }
@@ -459,13 +423,10 @@ class UserApiIT {
         ReadUser user = baseUserForTests;
 
         CreateUser userWithExistEmail = new CreateUser()
-                .firstName("firstName")
-                .middleName("middleName")
-                .lastName("lastName")
                 .password(ApiClientUtil.VALID_USER_PASSWORD)
                 .email(user.getEmail())
                 .registrationToken(RandomStringUtils.randomAlphabetic(36))
-                .contacts(createContactList());
+                .phoneNumber("380501112233");
 
         return userApi.createUserWithHttpInfo(userWithExistEmail);
     }

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/UserApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/users/UserApiIT.java
@@ -24,6 +24,7 @@ import com.softserveinc.ita.homeproject.client.model.Address;
 import com.softserveinc.ita.homeproject.client.model.ContactType;
 import com.softserveinc.ita.homeproject.client.model.CreateContact;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateEmailContact;
 import com.softserveinc.ita.homeproject.client.model.CreatePhoneContact;
 import com.softserveinc.ita.homeproject.client.model.CreateUser;
@@ -398,7 +399,8 @@ class UserApiIT {
                 .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
                 .usreo(RandomStringUtils.randomNumeric(8))
                 .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-                .adminEmail(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"))
+                .adminData(new CreateCooperationAdminData()
+                    .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com")))
                 .address(createAddress())
                 .contacts(createContactList());
     }
@@ -455,7 +457,7 @@ class UserApiIT {
     private ReadUser createNotMatchingUser() {
         CreateCooperation coop = createBaseCooperation();
         cooperationApi.createCooperation(coop);
-        String email = coop.getAdminEmail();
+        String email = coop.getAdminData().getEmail();
 
         ResponseEmailItem letter = MailUtil.waitLetterForEmail(email);
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
@@ -28,6 +28,7 @@ import com.softserveinc.ita.homeproject.client.model.CreateApartment;
 import com.softserveinc.ita.homeproject.client.model.CreateApartmentInvitation;
 import com.softserveinc.ita.homeproject.client.model.CreateContact;
 import com.softserveinc.ita.homeproject.client.model.CreateCooperation;
+import com.softserveinc.ita.homeproject.client.model.CreateCooperationAdminData;
 import com.softserveinc.ita.homeproject.client.model.CreateEmailContact;
 import com.softserveinc.ita.homeproject.client.model.CreateHouse;
 import com.softserveinc.ita.homeproject.client.model.CreateInvitation;
@@ -159,7 +160,7 @@ public final class ApiClientUtil {
     public static ReadUser createCooperationAdmin(CooperationApi cooperationApi, CreateCooperation coop,
                                                   UserApi userApi, CreateUser user) {
         cooperationApi.createCooperation(coop);
-        String email = coop.getAdminEmail();
+        String email = coop.getAdminData().getEmail();
 
         ResponseEmailItem letter = MailUtil.waitLetterForEmail(email);
 
@@ -173,7 +174,8 @@ public final class ApiClientUtil {
             .name(RandomStringUtils.randomAlphabetic(5).concat(" Cooperation"))
             .usreo(RandomStringUtils.randomNumeric(8))
             .iban("UA".concat(RandomStringUtils.randomNumeric(27)))
-            .adminEmail(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com"))
+            .adminData(new CreateCooperationAdminData()
+                .email(RandomStringUtils.randomAlphabetic(10).concat("@gmail.com")))
             .address(createAddress());
     }
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
@@ -190,12 +190,9 @@ public final class ApiClientUtil {
     private static CreateUser createBaseUser() {
 
         return new CreateUser()
-            .firstName("firstName")
-            .middleName("middleName")
-            .lastName("lastName")
             .password(VALID_USER_PASSWORD)
             .email("test.receive.apartment@gmail.com")
-            .contacts(createContactList());
+            .phoneNumber("380501112233");
     }
 
     private static List<CreateContact> createContactList() {

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/UserApiImpl.java
@@ -2,6 +2,7 @@ package com.softserveinc.ita.homeproject.application.api;
 
 import static com.softserveinc.ita.homeproject.application.security.constants.Permissions.MANAGE_USER;
 
+import java.util.List;
 import javax.annotation.security.PermitAll;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
@@ -10,6 +11,7 @@ import com.softserveinc.ita.homeproject.application.model.ContactType;
 import com.softserveinc.ita.homeproject.application.model.CreateContact;
 import com.softserveinc.ita.homeproject.application.model.CreateUser;
 import com.softserveinc.ita.homeproject.application.model.ReadContact;
+import com.softserveinc.ita.homeproject.application.model.ReadPhoneContact;
 import com.softserveinc.ita.homeproject.application.model.ReadUser;
 import com.softserveinc.ita.homeproject.application.model.UpdateContact;
 import com.softserveinc.ita.homeproject.application.model.UpdateUser;
@@ -58,10 +60,18 @@ public class UserApiImpl extends CommonApi implements UsersApi {
     @PermitAll
     @Override
     public Response createUser(CreateUser createUser) {
-        UserDto createUserDto = mapper.convert(createUser, UserDto.class);
-        UserDto readUserDto = userService.createUser(createUserDto);
-        ReadUser readUser = mapper.convert(readUserDto, ReadUser.class);
-
+        ReadContact phone = new ReadPhoneContact()
+            .phone("380501112233")
+            .id(1L)
+            .main(true)
+            .type(ContactType.PHONE);
+        ReadUser readUser = new ReadUser()
+            .id(1L)
+            .firstName("John")
+            .middleName("Charles")
+            .lastName("Doe")
+            .email("mail@mailbox.com")
+            .contacts(List.of(phone));
         return Response.status(Response.Status.CREATED).entity(readUser).build();
     }
 

--- a/home-open-api/src/main/resources/yaml/models/cooperation.yaml
+++ b/home-open-api/src/main/resources/yaml/models/cooperation.yaml
@@ -1,7 +1,7 @@
 CreateCooperation:
   required:
     - usreo
-    - admin_email
+    - admin_data
   type: object
   properties:
     name:
@@ -17,12 +17,40 @@ CreateCooperation:
       type: string
       example: "UA213223130000026007233566001"
       pattern: '^UA\d{27}$'
-    admin_email:
-      type: string
-      minLength: 5
-      maxLength: 320
-      pattern: '^([\w!#$%&''*+\/=?{|}~^-]|\.){1,60}@(?!-)(?:[a-zA-Z0-9-]{2,250}+\.)+[a-zA-Z]{2,6}$'
-      example: "test.receive.messages@gmail.com"
+    admin_data:
+      type: object
+      properties:
+        first_name:
+          pattern: '^([A-Za-zА-Яа-яґҐЁёІіЇїЄє''’ʼ]+[\s-]?)*'
+          type: string
+          example: "Petro"
+          minLength: 1
+          maxLength: 50
+        middle_name:
+          pattern: '^([A-Za-zА-Яа-яґҐЁёІіЇїЄє''’ʼ]+[\s-]?)*'
+          type: string
+          example: "Petrovich"
+          minLength: 1
+          maxLength: 50
+        last_name:
+          pattern: '^([A-Za-zА-Яа-яґҐЁёІіЇїЄє''’ʼ]+[\s-]?)*'
+          type: string
+          example: "Zinchenko"
+          minLength: 1
+          maxLength: 50
+        email:
+          pattern: '^([\w!#$%&''*+\/=?{|}~^-]|\.){1,60}@(?!-)(?:[a-zA-Z0-9-]{2,250}+\.)+[a-zA-Z]{2,6}$'
+          type: string
+          example: "p.t.z@gmail.com"
+          minLength: 5
+          maxLength: 320
+      example: {
+        "first_name": "John",
+        "middle_name": "Charles",
+        "last_name": "Doe",
+        "email": "mail@mailbox.com"
+      }
+
     address:
       $ref: 'address.yaml#/Address'
     houses:

--- a/home-open-api/src/main/resources/yaml/models/user.yaml
+++ b/home-open-api/src/main/resources/yaml/models/user.yaml
@@ -83,4 +83,3 @@ UpdateUser:
       example: "Petrov"
       minLength: 1
       maxLength: 50
-

--- a/home-open-api/src/main/resources/yaml/models/user.yaml
+++ b/home-open-api/src/main/resources/yaml/models/user.yaml
@@ -1,35 +1,19 @@
 CreateUser:
   required:
+    - id
     - registration_token
-    - first_name
-    - middle_name
-    - last_name
     - email
     - password
+    - phone_number
   type: object
   properties:
+    id:
+      type: integer
+      example: 1
     registration_token:
       type: string
       example: f8e20775-da55-11eb-a58d-775374b8f3a1
       minLength: 36
-    first_name:
-      pattern: '^([A-Za-zА-Яа-яґҐЁёІіЇїЄє''’ʼ]+[\s-]?)*'
-      type: string
-      example: "Petro"
-      minLength: 1
-      maxLength: 50
-    middle_name:
-      pattern: '^([A-Za-zА-Яа-яґҐЁёІіЇїЄє''’ʼ]+[\s-]?)*'
-      type: string
-      example: "Petrovich"
-      minLength: 1
-      maxLength: 50
-    last_name:
-      pattern: '^([A-Za-zА-Яа-яґҐЁёІіЇїЄє''’ʼ]+[\s-]?)*'
-      type: string
-      example: "Zinchenko"
-      minLength: 1
-      maxLength: 50
     email:
       pattern: '^([\w!#$%&''*+\/=?{|}~^-]|\.){1,60}@(?!-)(?:[a-zA-Z0-9-]{2,250}+\.)+[a-zA-Z]{2,6}$'
       type: string
@@ -39,20 +23,13 @@ CreateUser:
     password:
       pattern: '^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=\S+$).{8,}$'
       type: string
-      example: "mySuperStrongPass"
+      example: "mySuperStrongPass2"
       minLength: 8
       maxLength: 128
-    contacts:
-      type: array
-      example: [
-        {
-          "type": "email",
-          "main": false,
-          "email": "createUserEmail@example.com"
-        }
-      ]
-      items:
-        $ref: 'contact.yaml#/CreateContact'
+    phone_number:
+      type: string
+      example: 380501112233
+      minimum: 10
 ReadUser:
   allOf:
     - $ref: 'common.yaml#/BaseReadView'


### PR DESCRIPTION
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/480)


## Summary of issue

Due to new logic described in [ticket #478](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/478). Now users registries during apartment registration by its cooperation admin. So, users already created and stores in the database. Due to this changes in payload required.

## Summary of change

- Changed OpenApi specification
- Stabed controller
- Mock api tests

## Testing approach

Not Required

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
