### PR TITLE
Refactor openai specification

### DIFF
--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartments/ApartmentApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartments/ApartmentApiIT.java
@@ -284,8 +284,7 @@ class ApartmentApiIT {
     private CreateApartment createApartment(int numberOfApartmentInvitations) {
         return new CreateApartment()
                 .area(BigDecimal.valueOf(72.5))
-                .number("15")
-                .invitations(createApartmentInvitation(numberOfApartmentInvitations));
+                .number("15");
     }
 
     private List<CreateInvitation> createApartmentInvitation(int numberOfInvitations) {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartments/QueryApartmentIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/apartments/QueryApartmentIT.java
@@ -187,16 +187,14 @@ class QueryApartmentIT {
     private CreateApartment createSecondApartment(int numberOfApartamentInvitations) {
         return new CreateApartment()
             .area(BigDecimal.valueOf(65.5))
-            .number("16")
-            .invitations(createApartmentInvitation(numberOfApartamentInvitations));
+            .number("16");
     }
 
 
     private CreateApartment createApartment(int numberOfApartamentInvitations) {
         return new CreateApartment()
             .area(BigDecimal.valueOf(72.5))
-            .number("15")
-            .invitations(createApartmentInvitation(numberOfApartamentInvitations));
+            .number("15");
     }
 
     private List<CreateInvitation> createApartmentInvitation(int numberOfInvitations) {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/InvitationApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/InvitationApiIT.java
@@ -348,8 +348,7 @@ class InvitationApiIT {
     private CreateApartment createApartmentWithEmail(String userEmail) {
         return new CreateApartment()
                 .area(BigDecimal.valueOf(72.5))
-                .number("15")
-                .invitations(createApartmentInvitationWithEmail(userEmail));
+                .number("15");
     }
 
     private List<CreateInvitation> createApartmentInvitationWithEmail(String userEmail) {
@@ -370,8 +369,7 @@ class InvitationApiIT {
     private CreateApartment createApartment(int numberOfApartamentInvitations) {
         return new CreateApartment()
                 .area(BigDecimal.valueOf(72.5))
-                .number("15")
-                .invitations(createApartmentInvitation(numberOfApartamentInvitations));
+                .number("15");
     }
 
     private List<CreateInvitation> createApartmentInvitation(int numberOfInvitations) {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/QueryInvitationIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/invitations/QueryInvitationIT.java
@@ -268,8 +268,7 @@ public class QueryInvitationIT {
     private CreateApartment createApartment(int numberOfApartamentInvitations) {
         return new CreateApartment()
             .area(BigDecimal.valueOf(72.5))
-            .number("15")
-            .invitations(createApartmentInvitation(numberOfApartamentInvitations));
+            .number("15");
     }
 
 

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/ownerships/OwnershipApiIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/ownerships/OwnershipApiIT.java
@@ -78,8 +78,7 @@ class OwnershipApiIT {
             .collect(Collectors.toList());
 
         users.forEach(x -> {
-            String email = Objects.requireNonNull(
-                    createApartment.getInvitations().get(createApartment.getInvitations().size() - 1)).getEmail();
+            String email = "mailmock@mailbox.com";
             ResponseEmailItem letter = MailUtil.waitLetter(MailUtil.predicate().email(email).subject("apartment"));
             x.setRegistrationToken(MailUtil.getToken(letter));
             x.setEmail(email);
@@ -88,7 +87,6 @@ class OwnershipApiIT {
             } catch (ApiException e) {
                 e.printStackTrace();
             }
-            createApartment.getInvitations().remove(createApartment.getInvitations().size() - 1);
         });
 
         ownershipApi.queryOwnership(TEST_APARTMENT_ID, null, null, null, null, null, null, null)
@@ -103,7 +101,7 @@ class OwnershipApiIT {
         ReadHouse createdHouse = houseApi.createHouse(createdCooperation.getId(), createHouse());
         apartmentApi.createApartment(createdHouse.getId(), createApartment);
 
-        String email = Objects.requireNonNull(createApartment.getInvitations()).get(0).getEmail();
+        String email = "mailmock@mailbox.com";
         ResponseEmailItem letter = MailUtil.waitLetterForEmail(email);
         CreateUser expectedUser = createBaseUser();
         expectedUser.setRegistrationToken(MailUtil.getToken(letter));
@@ -273,8 +271,7 @@ class OwnershipApiIT {
     private CreateApartment createApartment(int numberOfApartamentInvitations) {
         return new CreateApartment()
             .area(BigDecimal.valueOf(72.5))
-            .number("15")
-            .invitations(createApartmentInvitation(numberOfApartamentInvitations));
+            .number("15");
     }
 
     private List<CreateInvitation> createApartmentInvitation(int numberOfInvitations) {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/ownerships/QueryOwnershipIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/ownerships/QueryOwnershipIT.java
@@ -68,8 +68,7 @@ class QueryOwnershipIT {
             .collect(Collectors.toList());
 
         users.forEach(x -> {
-            String email = Objects.requireNonNull(
-                    createApartment.getInvitations().get(createApartment.getInvitations().size() - 1)).getEmail();
+            String email = "emailmock@mailbox.com";
             ResponseEmailItem letter = MailUtil.waitLetter(MailUtil.predicate().email(email).subject("apartment"));
             x.setRegistrationToken(MailUtil.getToken(letter));
             x.setEmail(email);
@@ -78,7 +77,6 @@ class QueryOwnershipIT {
             } catch (ApiException e) {
                 e.printStackTrace();
             }
-            createApartment.getInvitations().remove(createApartment.getInvitations().size() - 1);
         });
 
         ownershipApi.queryOwnership(TEST_APARTMENT_ID, null, null, null, null, null, null, null)
@@ -231,8 +229,7 @@ class QueryOwnershipIT {
     private CreateApartment createApartment(int numberOfApartamentInvitations) {
         return new CreateApartment()
                 .area(BigDecimal.valueOf(72.5))
-                .number("15")
-                .invitations(createApartmentInvitation(numberOfApartamentInvitations));
+                .number("15");
     }
 
     private List<CreateInvitation> createApartmentInvitation(int numberOfInvitations) {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/security/PermissionsIT.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/security/PermissionsIT.java
@@ -677,8 +677,7 @@ class PermissionsIT {
     private static CreateApartment createApartment() {
         return new CreateApartment()
             .area(BigDecimal.valueOf(72.5))
-            .number("15")
-            .invitations(createInvitationList(NUMBER_OF_APARTMENT_INVITATIONS));
+            .number("15");
     }
 
     private static UpdatePoll updatePoll() {

--- a/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
+++ b/home-api-tests/src/test/java/com/softserveinc/ita/homeproject/api/tests/utils/ApiClientUtil.java
@@ -247,7 +247,7 @@ public final class ApiClientUtil {
         apartmentApi.createApartment(createdHouse.getId(), createApartment);
 
         CreateUser expectedUser = createBaseUser();
-        String email = Objects.requireNonNull(createApartment.getInvitations()).get(0).getEmail();
+        String email = "emailmock@mailbox.com";
         ResponseEmailItem letter = MailUtil.waitLetterForEmail(email);
         expectedUser.setRegistrationToken(MailUtil.getToken(letter));
         expectedUser.setEmail(email);
@@ -267,8 +267,7 @@ public final class ApiClientUtil {
     private static CreateApartment createApartment(int numberOfApartamentInvitations) {
         return new CreateApartment()
             .area(BigDecimal.valueOf(72.5))
-            .number("15")
-            .invitations(createApartmentInvitation(numberOfApartamentInvitations));
+            .number("15");
     }
 
     private static List<CreateInvitation> createApartmentInvitation(int numberOfInvitations) {

--- a/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/HouseApiImpl.java
+++ b/home-application/src/main/java/com/softserveinc/ita/homeproject/application/api/HouseApiImpl.java
@@ -5,11 +5,14 @@ import static com.softserveinc.ita.homeproject.application.security.constants.Pe
 import static com.softserveinc.ita.homeproject.application.security.constants.Permissions.READ_APARTMENT_INFO;
 
 import java.math.BigDecimal;
+import java.util.List;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
 import com.softserveinc.ita.homeproject.application.model.CreateApartment;
 import com.softserveinc.ita.homeproject.application.model.ReadApartment;
+import com.softserveinc.ita.homeproject.application.model.ReadOwner;
+import com.softserveinc.ita.homeproject.application.model.ReadOwnership;
 import com.softserveinc.ita.homeproject.application.model.UpdateApartment;
 import com.softserveinc.ita.homeproject.homeservice.dto.cooperation.apartment.ApartmentDto;
 import com.softserveinc.ita.homeproject.homeservice.service.cooperation.apartment.ApartmentService;
@@ -32,9 +35,30 @@ public class HouseApiImpl extends CommonApi implements HousesApi {
     @PreAuthorize(MANAGE_IN_COOPERATION)
     @Override
     public Response createApartment(Long houseId, CreateApartment createApartment) {
-        ApartmentDto createApartmentDto = mapper.convert(createApartment, ApartmentDto.class);
-        ApartmentDto readApartmentDto = apartmentService.createApartment(houseId, createApartmentDto);
-        ReadApartment readApartment = mapper.convert(readApartmentDto, ReadApartment.class);
+        ReadOwner owner1 = new ReadOwner()
+            .firstName("John")
+            .middleName("Charles")
+            .lastName("Doe")
+            .contacts(null)
+            .id(1L);
+        ReadOwner owner2 = new ReadOwner()
+            .firstName("Caren")
+            .middleName("Marry")
+            .lastName("Doe")
+            .contacts(null)
+            .id(2L);
+        ReadOwnership ownership1 = new ReadOwnership()
+            .owner(owner1)
+            .ownershipPart("0.7")
+            .id(1L);
+        ReadOwnership ownership2 = new ReadOwnership()
+            .owner(owner2)
+            .ownershipPart("0.3")
+            .id(2L);
+        ReadApartment readApartment = new ReadApartment()
+            .apartmentArea(new BigDecimal(75.25))
+            .apartmentNumber("23")
+            .ownerships(List.of(ownership1, ownership2));
 
         return Response.status(Response.Status.CREATED).entity(readApartment).build();
     }

--- a/home-open-api/src/main/resources/yaml/models/apartment.yaml
+++ b/home-open-api/src/main/resources/yaml/models/apartment.yaml
@@ -2,6 +2,7 @@ CreateApartment:
   required:
     - number
     - area
+    - ownerships
   type: object
   properties:
     number:
@@ -16,18 +17,23 @@ CreateApartment:
       maximum: 1000
       multipleOf: 1e-2
       example: 75.28
-    invitations:
+    ownerships:
       type: array
       items:
-        $ref: 'invitation.yaml#/CreateInvitation'
+        $ref: 'ownership.yaml#/CreateOwnership'
       example: [
         {
-          "email": "test.receive.messages@gmail.com",
-          "type": "apartment"
+          "type": "person",
+          "first_name": "Ivan",
+          "last_name": "Ivanov",
+          "middle_name": "Ivanovich",
+          "ownership_part": 0.3
         },
         {
-          "email": "test.receive.messages@gmail.com",
-          "type": "apartment"
+          "type": "legal_entity",
+          "name": "Company Inc.",
+          "edrpou": "12345678",
+          "ownership_part": 0.7
         }
       ]
 UpdateApartment:

--- a/home-open-api/src/main/resources/yaml/models/ownership.yaml
+++ b/home-open-api/src/main/resources/yaml/models/ownership.yaml
@@ -22,3 +22,33 @@ UpdateOwnership:
       maximum: 1.0
       multipleOf: 1e-4
       example: 0.6588
+CreateOwnership:
+  type: object
+  required:
+    - type
+    - ownership_part
+  properties:
+    type:
+      type: string
+      example: person
+    first_name:
+      type: string
+      example: John
+    last_name:
+      type: string
+      example: Doe
+    middle_name:
+      type: string
+      example: middleName
+    name:
+      type: string
+      example: Company Inc.
+    edrpou:
+      type: integer
+      example: 12345678
+    ownership_part:
+      type: string
+      minimum: 0.0001
+      maximum: 1.0
+      multipleOf: 1e-4
+      example: 0.6588


### PR DESCRIPTION
dev
## ZenHub

* [Main ZenHub ticket](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/481)

## Summary of issue

Due to new registration logic all information about ownerships should be filled by cooperation admin during apartment creation. There are 2 types of ownerships and required fields variates depends on this type. For more information about it see [ticket #478](https://app.zenhub.com/workspaces/home-project-5f7b77ff8db73a001cb17009/issues/ita-social-projects/home/478).

## Summary of change

- Changed OpenApi specification
- Stab controller
- Mock api tests

## Testing approach

Not required

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
